### PR TITLE
refactor: use json.Unmarshal instead of Decode

### DIFF
--- a/collector/cluster_health.go
+++ b/collector/cluster_health.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -246,7 +247,13 @@ func (c *ClusterHealth) fetchAndDecodeClusterHealth() (clusterHealthResponse, er
 		return chr, fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&chr); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		c.jsonParseFailures.Inc()
+		return chr, err
+	}
+
+	if err := json.Unmarshal(bts, &chr); err != nil {
 		c.jsonParseFailures.Inc()
 		return chr, err
 	}

--- a/collector/cluster_settings.go
+++ b/collector/cluster_settings.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -86,10 +87,17 @@ func (cs *ClusterSettings) getAndParseURL(u *url.URL, data interface{}) error {
 		return fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(data); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
 		cs.jsonParseFailures.Inc()
 		return err
 	}
+
+	if err := json.Unmarshal(bts, data); err != nil {
+		cs.jsonParseFailures.Inc()
+		return err
+	}
+
 	return nil
 }
 

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -1050,7 +1051,13 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 		return isr, fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&isr); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		i.jsonParseFailures.Inc()
+		return isr, err
+	}
+
+	if err := json.Unmarshal(bts, &isr); err != nil {
 		i.jsonParseFailures.Inc()
 		return isr, err
 	}

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -78,7 +79,13 @@ func (cs *IndicesSettings) getAndParseURL(u *url.URL, data interface{}) error {
 		return fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(data); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		cs.jsonParseFailures.Inc()
+		return err
+	}
+
+	if err := json.Unmarshal(bts, data); err != nil {
 		cs.jsonParseFailures.Inc()
 		return err
 	}

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -1829,7 +1830,13 @@ func (c *Nodes) fetchAndDecodeNodeStats() (nodeStatsResponse, error) {
 		return nsr, fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&nsr); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		c.jsonParseFailures.Inc()
+		return nsr, err
+	}
+
+	if err := json.Unmarshal(bts, &nsr); err != nil {
 		c.jsonParseFailures.Inc()
 		return nsr, err
 	}

--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -218,7 +219,13 @@ func (s *Snapshots) getAndParseURL(u *url.URL, data interface{}) error {
 		return fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(data); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		s.jsonParseFailures.Inc()
+		return err
+	}
+
+	if err := json.Unmarshal(bts, data); err != nil {
 		s.jsonParseFailures.Inc()
 		return err
 	}

--- a/pkg/clusterinfo/clusterinfo.go
+++ b/pkg/clusterinfo/clusterinfo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -271,7 +272,12 @@ func (r *Retriever) fetchAndDecodeClusterInfo() (*Response, error) {
 		return nil, fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
 	}
 
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+	bts, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(bts, &response); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
According to go docs, [`json.Decoder`](https://godoc.org/encoding/json#Decoder) should be used to decode stream of JSONs, which I think its not the case for us.

I don't know if it is still 100% valid, [this article](https://ahmet.im/blog/golang-json-decoder-pitfalls/) explains some unintended side effects of it.