### PR TITLE
fix metric name for gc counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Further Information
 | elasticsearch_indices_translog_size_in_bytes                          | counter   | 1           | Total translog size in bytes
 | elasticsearch_indices_warmer_time_seconds_total                       | counter   | 1           | Total warmer time in seconds
 | elasticsearch_indices_warmer_total                                    | counter   | 1           | Total warmer count
-| elasticsearch_jvm_gc_collection_seconds_count                         | counter   | 2           | Count of JVM GC runs
+| elasticsearch_jvm_gc_collection_count                                 | counter   | 2           | Count of JVM GC runs
 | elasticsearch_jvm_gc_collection_seconds_sum                           | counter   | 2           | GC run time in seconds
 | elasticsearch_jvm_memory_committed_bytes                              | gauge     | 2           | JVM memory currently committed by area
 | elasticsearch_jvm_memory_max_bytes                                    | gauge     | 1           | JVM memory max

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1515,7 +1515,7 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "jvm_gc", "collection_seconds_count"),
+					prometheus.BuildFQName(namespace, "jvm_gc", "collection_count"),
 					"Count of JVM GC runs",
 					append(defaultNodeLabels, "gc"), nil,
 				),


### PR DESCRIPTION
Hello and thanks for this great exporter! I have noticed that there is a typo in `elasticsearch_jvm_gc_collection_seconds_count` metric which actually counts gc events and not seconds.