### PR TITLE
feat: snapshots interval

### DIFF
--- a/collector/snapshots_test.go
+++ b/collector/snapshots_test.go
@@ -44,7 +44,7 @@ func TestSnapshots(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		s := NewSnapshots(log.NewNopLogger(), http.DefaultClient, u)
+		s := NewSnapshots(log.NewNopLogger(), http.DefaultClient, u, 0)
 		stats, err := s.fetchAndDecodeSnapshotsStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode snapshots stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ func main() {
 		esExportSnapshots = kingpin.Flag("es.snapshots",
 			"Export stats for the cluster snapshots.").
 			Default("false").Envar("ES_SNAPSHOTS").Bool()
+		esSnapshotsInterval = kingpin.Flag("es.snapshots.interval",
+			"Snapshots metrics update interval").
+			Default("0s").Envar("ES_SNAPSHOTS_INTERVAL").Duration()
 		esClusterInfoInterval = kingpin.Flag("es.clusterinfo.interval",
 			"Cluster info update interval for the cluster label").
 			Default("5m").Envar("ES_CLUSTERINFO_INTERVAL").Duration()
@@ -125,7 +128,7 @@ func main() {
 	}
 
 	if *esExportSnapshots {
-		prometheus.MustRegister(collector.NewSnapshots(logger, httpClient, esURL))
+		prometheus.MustRegister(collector.NewSnapshots(logger, httpClient, esURL, *esSnapshotsInterval))
 	}
 
 	if *esExportClusterSettings {


### PR DESCRIPTION
We have snapshots on GCS, and gathering snapshots metrics takes ~2min sometimes, causing the whole thing to timeout often.

My idea with this one is to get snapshots metrics only every now and then, and do so in background.

The old behavior is still the default, and this new behavior is opt-in.

what do you think?