### PR TITLE
add jvm.mem.heap_used_percent

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1180,6 +1180,20 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 					return append(defaultNodeLabelValues(cluster, node), "young")
 				},
 			},
+                        {
+                                Type: prometheus.GaugeValue,
+                                Desc: prometheus.NewDesc(
+                                        prometheus.BuildFQName(namespace, "jvm_memory", "used_percent"),
+                                        "percent of JVM memory used",
+                                        append(defaultNodeLabels, "area"), nil,
+                                ),
+                                Value: func(node NodeStatsNodeResponse) float64 {
+                                        return float64(node.JVM.Mem.HeapPercent)
+                                },
+                                Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+                                        return append(defaultNodeLabelValues(cluster, node), "heap")
+                                },
+                        },
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -79,7 +79,6 @@ type NodeStatsJVMMemPoolResponse struct {
 	Max      int64 `json:"max_in_bytes"`
 	PeakUsed int64 `json:"peak_used_in_bytes"`
 	PeakMax  int64 `json:"peak_max_in_bytes"`
-        Percent  int64 `json:"heap_used_percent"`
 }
 
 // NodeStatsNetworkResponse defines node stats network information structure

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -70,6 +70,7 @@ type NodeStatsJVMMemResponse struct {
 	NonHeapCommitted int64                                  `json:"non_heap_committed_in_bytes"`
 	NonHeapUsed      int64                                  `json:"non_heap_used_in_bytes"`
 	Pools            map[string]NodeStatsJVMMemPoolResponse `json:"pools"`
+	HeapPercent	 int64					`json:"heap_used_percent"`
 }
 
 // NodeStatsJVMMemPoolResponse defines node stats JVM memory pool information structure
@@ -78,6 +79,7 @@ type NodeStatsJVMMemPoolResponse struct {
 	Max      int64 `json:"max_in_bytes"`
 	PeakUsed int64 `json:"peak_used_in_bytes"`
 	PeakMax  int64 `json:"peak_max_in_bytes"`
+        Percent  int64 `json:"heap_used_percent"`
 }
 
 // NodeStatsNetworkResponse defines node stats network information structure


### PR DESCRIPTION
we needed the percentage JVM memory used by Heap in order to monitor when we reach 85% utilization of memory, same as we do for cpu.


output in our case looks like the following:
```
# HELP elasticsearch_jvm_memory_used_percent percent of JVM memory used
# TYPE elasticsearch_jvm_memory_used_percent gauge
elasticsearch_jvm_memory_used_percent{area="heap",cluster="xxxxxxx",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="xxx",name="instance-1"} 79
elasticsearch_jvm_memory_used_percent{area="heap",cluster="xxxxxx",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="xxxxx",name="instance-2"} 69
elasticsearch_jvm_memory_used_percent{area="heap",cluster="xxxxxx",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="xxxxx",name="instance-3"} 73
```