### PR TITLE
feat: allow Prometheus namespace to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ elasticsearch_exporter --help
 | es.client-cert          | 1.0.2                 | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. | |
 | es.clusterinfo.interval | 1.1.0rc1              |  Cluster info update interval for the cluster label | 5m |
 | es.ssl-skip-verify      | 1.0.4rc1              | Skip SSL verification when connecting to Elasticsearch. | false |
+| prom.namespace          | next                  | Prometheus metrics namespace. | elasticsearch |
 | web.listen-address      | 1.0.2                 | Address to listen on for web interface and telemetry. | :9114 |
 | web.telemetry-path      | 1.0.2                 | Path under which to expose metrics. | /metrics |
 | version                 | 1.0.2                 | Show version info on stdout and exit. | |

--- a/collector/cluster_health.go
+++ b/collector/cluster_health.go
@@ -12,10 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	namespace = "elasticsearch"
-)
-
 var (
 	colors                     = []string{"green", "yellow", "red"}
 	defaultClusterHealthLabels = []string{"cluster"}
@@ -48,7 +44,7 @@ type ClusterHealth struct {
 }
 
 // NewClusterHealth returns a new Collector exposing ClusterHealth stats.
-func NewClusterHealth(logger log.Logger, client *http.Client, url *url.URL) *ClusterHealth {
+func NewClusterHealth(logger log.Logger, client *http.Client, url *url.URL, namespace string) *ClusterHealth {
 	subsystem := "cluster_health"
 
 	return &ClusterHealth{

--- a/collector/cluster_health_test.go
+++ b/collector/cluster_health_test.go
@@ -30,7 +30,7 @@ func TestClusterHealth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		c := NewClusterHealth(log.NewNopLogger(), http.DefaultClient, u)
+		c := NewClusterHealth(log.NewNopLogger(), http.DefaultClient, u, "elasticsearch")
 		chr, err := c.fetchAndDecodeClusterHealth()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode cluster health: %s", err)

--- a/collector/cluster_settings.go
+++ b/collector/cluster_settings.go
@@ -27,7 +27,7 @@ type ClusterSettings struct {
 }
 
 // NewClusterSettings defines Cluster Settings Prometheus metrics
-func NewClusterSettings(logger log.Logger, client *http.Client, url *url.URL) *ClusterSettings {
+func NewClusterSettings(logger log.Logger, client *http.Client, url *url.URL, namespace string) *ClusterSettings {
 	return &ClusterSettings{
 		logger: logger,
 		client: client,

--- a/collector/cluster_settings_test.go
+++ b/collector/cluster_settings_test.go
@@ -31,7 +31,7 @@ func TestClusterSettingsStats(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewClusterSettings(log.NewNopLogger(), http.DefaultClient, u)
+			c := NewClusterSettings(log.NewNopLogger(), http.DefaultClient, u, "elasticsearch")
 			nsr, err := c.fetchAndDecodeClusterSettingsStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode cluster settings stats: %s", err)
@@ -66,7 +66,7 @@ func TestClusterMaxShardsPerNode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewClusterSettings(log.NewNopLogger(), http.DefaultClient, u)
+			c := NewClusterSettings(log.NewNopLogger(), http.DefaultClient, u, "elasticsearch")
 			nsr, err := c.fetchAndDecodeClusterSettingsStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode cluster settings stats: %s", err)

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -45,14 +45,14 @@ type Indices struct {
 	up                prometheus.Gauge
 	totalScrapes      prometheus.Counter
 	jsonParseFailures prometheus.Counter
+	namespace         string
 
 	indexMetrics []*indexMetric
 	shardMetrics []*shardMetric
 }
 
 // NewIndices defines Indices Prometheus metrics
-func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool) *Indices {
-
+func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool, namespace string) *Indices {
 	indexLabels := labels{
 		keys: func(...string) []string {
 			return []string{"index", "cluster"}
@@ -984,6 +984,7 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 				Labels: shardLabels,
 			},
 		},
+		namespace: namespace,
 	}
 
 	// start go routine to fetch clusterinfo updates and save them to lastClusterinfo
@@ -1008,7 +1009,7 @@ func (i *Indices) ClusterLabelUpdates() *chan *clusterinfo.Response {
 
 // String implements the stringer interface. It is part of the clusterinfo.consumer interface
 func (i *Indices) String() string {
-	return namespace + "indices"
+	return i.namespace + "indices"
 }
 
 // Describe add Indices metrics descriptions

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -24,7 +24,7 @@ type IndicesSettings struct {
 }
 
 // NewIndicesSettings defines Indices Settings Prometheus metrics
-func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *IndicesSettings {
+func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL, namespace string) *IndicesSettings {
 	return &IndicesSettings{
 		logger: logger,
 		client: client,

--- a/collector/indices_settings_test.go
+++ b/collector/indices_settings_test.go
@@ -52,7 +52,7 @@ func TestIndicesSettings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u)
+			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u, "elasticsearch")
 			nsr, err := c.fetchAndDecodeIndicesSettings()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode indices settings: %s", err)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -35,7 +35,7 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, "elasticsearch")
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -44,7 +44,7 @@ func TestNodesStats(t *testing.T) {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
 			u.User = url.UserPassword("elastic", "changeme")
-			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true, "_local")
+			c := NewNodes(log.NewNopLogger(), http.DefaultClient, u, true, "_local", "elasticsearch")
 			nsr, err := c.fetchAndDecodeNodeStats()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode node stats: %s", err)

--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -51,7 +51,7 @@ type Snapshots struct {
 }
 
 // NewSnapshots defines Snapshots Prometheus metrics
-func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL) *Snapshots {
+func NewSnapshots(logger log.Logger, client *http.Client, url *url.URL, namespace string) *Snapshots {
 	return &Snapshots{
 		logger: logger,
 		client: client,

--- a/collector/snapshots_test.go
+++ b/collector/snapshots_test.go
@@ -44,7 +44,7 @@ func TestSnapshots(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		s := NewSnapshots(log.NewNopLogger(), http.DefaultClient, u)
+		s := NewSnapshots(log.NewNopLogger(), http.DefaultClient, u, "elasticsearch")
 		stats, err := s.fetchAndDecodeSnapshotsStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode snapshots stats: %s", err)

--- a/pkg/clusterinfo/clusterinfo.go
+++ b/pkg/clusterinfo/clusterinfo.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	namespace = "elasticsearch"
 	subsystem = "clusterinfo"
 )
 
@@ -51,7 +50,7 @@ type Retriever struct {
 }
 
 // New creates a new Retriever
-func New(logger log.Logger, client *http.Client, u *url.URL, interval time.Duration) *Retriever {
+func New(logger log.Logger, client *http.Client, u *url.URL, interval time.Duration, namespace string) *Retriever {
 	return &Retriever{
 		consumerChannels: make(map[string]*chan *Response),
 		logger:           logger,

--- a/pkg/clusterinfo/clusterinfo_test.go
+++ b/pkg/clusterinfo/clusterinfo_test.go
@@ -95,7 +95,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Skipf("internal test error: %s", err)
 	}
-	r := New(log.NewNopLogger(), http.DefaultClient, u, 0)
+	r := New(log.NewNopLogger(), http.DefaultClient, u, 0, "elasticsearch")
 	if r.url != u {
 		t.Errorf("new Retriever mal-constructed")
 	}
@@ -107,7 +107,7 @@ func TestRetriever_RegisterConsumer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("internal test error: %s", err)
 	}
-	retriever := New(log.NewNopLogger(), mockES.Client(), u, 0)
+	retriever := New(log.NewNopLogger(), mockES.Client(), u, 0, "elasticsearch")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	consumerNames := []string{"consumer-1", "consumer-2"}
@@ -146,7 +146,7 @@ func TestRetriever_fetchAndDecodeClusterInfo(t *testing.T) {
 	if err != nil {
 		t.Skipf("internal test error: %s", err)
 	}
-	retriever := New(log.NewNopLogger(), mockES.Client(), u, 0)
+	retriever := New(log.NewNopLogger(), mockES.Client(), u, 0, "elasticsearch")
 	ci, err := retriever.fetchAndDecodeClusterInfo()
 	if err != nil {
 		t.Fatalf("failed to retrieve cluster info: %s", err)
@@ -166,7 +166,7 @@ func TestRetriever_Run(t *testing.T) {
 	}
 
 	// setup cluster info retriever
-	retriever := New(log.NewLogfmtLogger(os.Stdout), mockES.Client(), u, 0)
+	retriever := New(log.NewLogfmtLogger(os.Stdout), mockES.Client(), u, 0, "elasticsearch")
 
 	// setup mock consumer
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
I need to use a different Prometheus namespace, so I made it configurable with `prom.namespace` or `PROM_NAMESPACE`.