### PR TITLE
Fix elasticsearch_index_stats_total_scrapes counter

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1077,7 +1077,6 @@ func (i *Indices) Collect(ch chan<- prometheus.Metric) {
 		)
 		return
 	}
-	i.totalScrapes.Inc()
 	i.up.Set(1)
 
 	// Index stats


### PR DESCRIPTION
Remove duplicating increment `elasticsearch_index_stats_total_scrapes` counter