### PR TITLE
fix(test): resolve test race conditions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,7 @@ jobs:
 
     steps:
     - prometheus/setup_environment
-    # TODO: Fix test issues to use plain `make` test.
-    - run: make precheck style check_license lint unused build
+    - run: make
     - prometheus/store_artifact:
         file: elasticsearch_exporter
 

--- a/pkg/clusterinfo/clusterinfo_test.go
+++ b/pkg/clusterinfo/clusterinfo_test.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -72,8 +73,11 @@ func (mockES) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 type mockConsumer struct {
 	name string
+
+	mu   sync.RWMutex
 	data *Response
-	ch   chan *Response
+
+	ch chan *Response
 }
 
 func newMockConsumer(ctx context.Context, name string, t *testing.T) *mockConsumer {
@@ -85,7 +89,9 @@ func newMockConsumer(ctx context.Context, name string, t *testing.T) *mockConsum
 		for {
 			select {
 			case d := <-mc.ch:
+				mc.mu.Lock()
 				mc.data = d
+				mc.mu.Unlock()
 				t.Logf("consumer %s received data from channel: %+v\n", mc, mc.data)
 			case <-ctx.Done():
 				return
@@ -93,6 +99,12 @@ func newMockConsumer(ctx context.Context, name string, t *testing.T) *mockConsum
 		}
 	}()
 	return mc
+}
+
+func (mc *mockConsumer) getData() Response {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return *mc.data
 }
 
 func (mc *mockConsumer) String() string {
@@ -196,7 +208,7 @@ func TestRetriever_Run(t *testing.T) {
 	retriever.Update()
 	time.Sleep(20 * time.Millisecond)
 	// ToDo: check mockConsumers received data
-	t.Logf("%+v\n", mc.data)
+	t.Logf("%+v\n", mc.getData())
 
 	// check for deadlocks
 	select {

--- a/pkg/clusterinfo/clusterinfo_test.go
+++ b/pkg/clusterinfo/clusterinfo_test.go
@@ -91,8 +91,8 @@ func newMockConsumer(ctx context.Context, name string, t *testing.T) *mockConsum
 			case d := <-mc.ch:
 				mc.mu.Lock()
 				mc.data = d
-				mc.mu.Unlock()
 				t.Logf("consumer %s received data from channel: %+v\n", mc, mc.data)
+				mc.mu.Unlock()
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
Fix a race condition in pkg/clusterinfo mockConsumer by protecting the data with a mutex. This resolves the issue where `make` fails to complete the build and tests.