### PR TITLE
Revert "fix metric name for gc counter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Further Information
 | elasticsearch_indices_translog_size_in_bytes                          | counter   | 1           | Total translog size in bytes
 | elasticsearch_indices_warmer_time_seconds_total                       | counter   | 1           | Total warmer time in seconds
 | elasticsearch_indices_warmer_total                                    | counter   | 1           | Total warmer count
-| elasticsearch_jvm_gc_collection_count                                 | counter   | 2           | Count of JVM GC runs
+| elasticsearch_jvm_gc_collection_seconds_count                         | counter   | 2           | Count of JVM GC runs
 | elasticsearch_jvm_gc_collection_seconds_sum                           | counter   | 2           | GC run time in seconds
 | elasticsearch_jvm_memory_committed_bytes                              | gauge     | 2           | JVM memory currently committed by area
 | elasticsearch_jvm_memory_max_bytes                                    | gauge     | 1           | JVM memory max

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1529,7 +1529,7 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "jvm_gc", "collection_count"),
+					prometheus.BuildFQName(namespace, "jvm_gc", "collection_seconds_count"),
 					"Count of JVM GC runs",
 					append(defaultNodeLabels, "gc"), nil,
 				),


### PR DESCRIPTION
Reverts prometheus-community/elasticsearch_exporter#324

This was a breaking change and will be re-addressed after a stable release is cut.