### PR TITLE
fix _/node/stats related metrics

### DIFF
--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -37,7 +37,7 @@ type NodeStatsNodeResponse struct {
 	ThreadPool       map[string]NodeStatsThreadPoolPoolResponse `json:"thread_pool"`
 	JVM              NodeStatsJVMResponse                       `json:"jvm"`
 	Breakers         map[string]NodeStatsBreakersResponse       `json:"breakers"`
-	HTTP             map[string]int                             `json:"http"`
+	HTTP             map[string]interface{}                     `json:"http"`
 	Transport        NodeStatsTransportResponse                 `json:"transport"`
 	Process          NodeStatsProcessResponse                   `json:"process"`
 }

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -51,11 +51,6 @@ func TestNodesStats(t *testing.T) {
 		for hn, handler := range handlers {
 			t.Run(fmt.Sprintf("%s/%s", hn, ver), func(t *testing.T) {
 
-				// TODO(@sysadmind): Remove this skip once we have a fix for v7.13.1 of elasticsearch
-				if ver == "7.13.1" {
-					t.Skip("7.13.1 has a breaking change and the fix has not yet been implemented.")
-				}
-
 				ts := httptest.NewServer(handler)
 				defer ts.Close()
 


### PR DESCRIPTION
Since Elasticsearch 7.13 the node related metrics are broken. It relates to a API change in Elasticsearch which breaks the unmarshling:

```
level=warn ts=2021-06-15T09:53:13.626727Z caller=nodes.go:1871 msg="failed to fetch and decode node stats" err="json: cannot unmarshal array into Go struct field NodeStatsNodeResponse.Nodes.http of type int"
```

The `HTTP` field will only checked for the roles and also only as `len(HTTP)`, so it seems it is not important to have the type here. 

Example for http field in the response (Elasticsearch 7.13)

```json
    {
      "id": 299723549,
      "agent": "curl/7.61.1",
      "local_address": "127.0.0.1:9200",
      "remote_address": "127.0.0.1:41480",
      "last_uri": "/",
      "opened_time_millis": 1623753253078,
      "closed_time_millis": 1623753253078,
      "last_request_time_millis": 1623753253078,
      "request_count": 1,
      "request_size_bytes": 0
    },
```

Related #419