### PR TITLE
Refactor tests for cluster health collector

### DIFF
--- a/fixtures/clusterhealth/5.4.2.json
+++ b/fixtures/clusterhealth/5.4.2.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}

--- a/fixtures/clusterhealth/5.6.16.json
+++ b/fixtures/clusterhealth/5.6.16.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}

--- a/fixtures/clusterhealth/6.5.4.json
+++ b/fixtures/clusterhealth/6.5.4.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}

--- a/fixtures/clusterhealth/6.8.8.json
+++ b/fixtures/clusterhealth/6.8.8.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}

--- a/fixtures/clusterhealth/7.13.1.json
+++ b/fixtures/clusterhealth/7.13.1.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}

--- a/fixtures/clusterhealth/7.3.0.json
+++ b/fixtures/clusterhealth/7.3.0.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}

--- a/fixtures/clusterhealth/7.6.2.json
+++ b/fixtures/clusterhealth/7.6.2.json
@@ -1,0 +1,17 @@
+{
+  "cluster_name": "elasticsearch",
+  "status": "yellow",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 30,
+  "active_shards": 30,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 30,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 12,
+  "active_shards_percent_as_number": 50
+}


### PR DESCRIPTION
This adds a more robust test for the cluster health collector by abstracting the parsing of a response into a single function. Fixtures have been added for multiple elasticsearch versions to ensure compatibility. This is in preparation for a larger refactoring and will ensure that future changes maintain the desired functionality.