### PR TITLE
Fix snapshot_stats metrics which happens on HA hdfs type snapshot rep…

### DIFF
--- a/collector/snapshots_reponse.go
+++ b/collector/snapshots_reponse.go
@@ -43,6 +43,6 @@ type SnapshotStatDataResponse struct {
 
 // SnapshotRepositoriesResponse is a representation snapshots repositories
 type SnapshotRepositoriesResponse map[string]struct {
-	Type     string            `json:"type"`
-	Settings map[string]string `json:"settings"`
+	Type     string                 `json:"type"`
+	Settings map[string]interface{} `json:"settings"`
 }

--- a/collector/snapshots_reponse.go
+++ b/collector/snapshots_reponse.go
@@ -43,6 +43,5 @@ type SnapshotStatDataResponse struct {
 
 // SnapshotRepositoriesResponse is a representation snapshots repositories
 type SnapshotRepositoriesResponse map[string]struct {
-	Type     string                 `json:"type"`
-	Settings map[string]interface{} `json:"settings"`
+	Type string `json:"type"`
 }


### PR DESCRIPTION
…ository

fix issue https://github.com/prometheus-community/elasticsearch_exporter/issues/415
err logs: "failed to fetch and decode snapshot stats" err:"json: cannot unmarshal object into Go struct field .settings of type string" "

repository-hdfs is an elasticsearch plugin: https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-hdfs-config.html#repository-hdfs-config