### PR TITLE
fix collecting index stats 400 error

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1041,7 +1041,9 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 	u := *i.url
 	u.Path = path.Join(u.Path, "/_all/_stats")
 	if i.shards {
-		u.RawQuery = "level=shards"
+		u.RawQuery = "ignore_unavailable=true&level=shards"
+	} else {
+		u.RawQuery = "ignore_unavailable=true"
 	}
 
 	res, err := i.client.Get(u.String())


### PR DESCRIPTION
add the query string `ignore_unavailable=true` for `_all/_stats` api

Fix  #444 