### PR TITLE
Add the ability to use ApiKey based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ elasticsearch_exporter --help
 | es.client-cert          | 1.0.2                 | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. | |
 | es.clusterinfo.interval | 1.1.0rc1              |  Cluster info update interval for the cluster label | 5m |
 | es.ssl-skip-verify      | 1.0.4rc1              | Skip SSL verification when connecting to Elasticsearch. | false |
+| es.apiKey               | unreleased            | Skip SSL verification when connecting to Elasticsearch. | false |
 | web.listen-address      | 1.0.2                 | Address to listen on for web interface and telemetry. | :9114 |
 | web.telemetry-path      | 1.0.2                 | Path under which to expose metrics. | /metrics |
 | version                 | 1.0.2                 | Show version info on stdout and exit. | |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ elasticsearch_exporter --help
 | es.client-cert          | 1.0.2                 | Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch. | |
 | es.clusterinfo.interval | 1.1.0rc1              |  Cluster info update interval for the cluster label | 5m |
 | es.ssl-skip-verify      | 1.0.4rc1              | Skip SSL verification when connecting to Elasticsearch. | false |
-| es.apiKey               | unreleased            | Skip SSL verification when connecting to Elasticsearch. | false |
+| es.apiKey               | unreleased            | API Key to use for authenticating against Elasticsearch. |  |
 | web.listen-address      | 1.0.2                 | Address to listen on for web interface and telemetry. | :9114 |
 | web.telemetry-path      | 1.0.2                 | Path under which to expose metrics. | /metrics |
 | version                 | 1.0.2                 | Show version info on stdout and exit. | |

--- a/main.go
+++ b/main.go
@@ -128,25 +128,25 @@ func main() {
 	// returns nil if not provided and falls back to simple TCP.
 	tlsConfig := createTLSConfig(*esCA, *esClientCert, *esClientPrivateKey, *esInsecureSkipVerify)
 
-	httpTransport := &http.Transport{
+	var httpTransport http.RoundTripper
+
+	httpTransport = &http.Transport{
 		TLSClientConfig: tlsConfig,
 		Proxy:           http.ProxyFromEnvironment,
+	}
+
+	if *esApiKey != "" {
+		apiKey := *esApiKey
+
+		httpTransport = &transportWithApiKey{
+			underlyingTransport: httpTransport,
+			apiKey:              apiKey,
+		}
 	}
 
 	httpClient := &http.Client{
 		Timeout:   *esTimeout,
 		Transport: httpTransport,
-	}
-
-	if *esApiKey != "" {
-		apiKey := *esApiKey
-		httpClient = &http.Client{
-			Timeout: *esTimeout,
-			Transport: &transportWithApiKey{
-				underlyingTransport: httpTransport,
-				apiKey:              apiKey,
-			},
-		}
 	}
 
 	// version metric

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -33,11 +34,11 @@ import (
 
 type transportWithApiKey struct {
 	underlyingTransport http.RoundTripper
-	apiKey              *string
+	apiKey              string
 }
 
 func (t *transportWithApiKey) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("Authorization", "ApiKey "+*t.apiKey)
+	req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", t.apiKey))
 	return t.underlyingTransport.RoundTrip(req)
 }
 
@@ -138,11 +139,12 @@ func main() {
 	}
 
 	if *esApiKey != "" {
+		apiKey := *esApiKey
 		httpClient = &http.Client{
 			Timeout: *esTimeout,
 			Transport: &transportWithApiKey{
 				underlyingTransport: httpTransport,
-				apiKey:              esApiKey,
+				apiKey:              apiKey,
 			},
 		}
 	}


### PR DESCRIPTION
If you're using Elasticsearch on Elastic Cloud the only way to authenticate is using [API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html). 
This PR adds the ability to define the API Key and set it as Authorization header with every request.

Please let me know if I can improve anything about the implementation!

Fixes #454 