### PR TITLE
Clean up main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func main() {
 	// create a http server
 	server := &http.Server{}
 
-	// create a context that is cancelled on SIGKILL or SIGINT
+	// Create a context that is cancelled on SIGKILL or SIGINT.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
 
@@ -262,5 +262,4 @@ func main() {
 	srvCtx, srvCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer srvCancel()
 	_ = server.Shutdown(srvCtx)
-
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
+const name = "elasticsearch_exporter"
+
 type transportWithApiKey struct {
 	underlyingTransport http.RoundTripper
 	apiKey              string
@@ -44,7 +46,6 @@ func (t *transportWithApiKey) RoundTrip(req *http.Request) (*http.Response, erro
 
 func main() {
 	var (
-		Name          = "elasticsearch_exporter"
 		listenAddress = kingpin.Flag("web.listen-address",
 			"Address to listen on for web interface and telemetry.").
 			Default(":9114").Envar("WEB_LISTEN_ADDRESS").String()
@@ -110,7 +111,7 @@ func main() {
 			Default("stdout").Envar("LOG_OUTPUT").String()
 	)
 
-	kingpin.Version(version.Print(Name))
+	kingpin.Version(version.Print(name))
 	kingpin.CommandLine.HelpFlag.Short('h')
 	kingpin.Parse()
 
@@ -157,8 +158,7 @@ func main() {
 	}
 
 	// version metric
-	versionMetric := version.NewCollector(Name)
-	prometheus.MustRegister(versionMetric)
+	prometheus.MustRegister(version.NewCollector(name))
 
 	// cluster info retriever
 	clusterInfoRetriever := clusterinfo.New(logger, httpClient, esURL, *esClusterInfoInterval)
@@ -194,8 +194,9 @@ func main() {
 	// create a http server
 	server := &http.Server{}
 
-	// create a context that is cancelled on SIGKILL
-	ctx, cancel := context.WithCancel(context.Background())
+	// create a context that is cancelled on SIGKILL or SIGINT
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
 
 	// start the cluster info retriever
 	switch runErr := clusterInfoRetriever.Run(ctx); runErr {
@@ -255,14 +256,11 @@ func main() {
 		}
 	}()
 
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-
+	<-ctx.Done()
+	_ = level.Info(logger).Log("msg", "shutting down")
 	// create a context for graceful http server shutdown
 	srvCtx, srvCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer srvCancel()
-	<-c
-	_ = level.Info(logger).Log("msg", "shutting down")
 	_ = server.Shutdown(srvCtx)
-	cancel()
+
 }


### PR DESCRIPTION
- Remove signal channel in favor of signal.NotifyContext
- Move shutdown context creation after signal wait so that the timeout is valid during shutdown
