### PR TITLE
number_of_replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Further Information
 | elasticsearch_indices_segments_memory_bytes                           | gauge     | 1           | Current memory size of segments in bytes
 | elasticsearch_indices_settings_stats_read_only_indices                | gauge     | 1           | Count of indices that have read_only_allow_delete=true
 | elasticsearch_indices_settings_total_fields                           | gauge     |             | Index setting value for index.mapping.total_fields.limit (total allowable mapped fields in a index)
+| elasticsearch_indices_settings_number_of_replicas                     | gauge     |             | Index setting value for index.number_of_replicas
 | elasticsearch_indices_shards_docs                                     | gauge     | 3           | Count of documents on this shard
 | elasticsearch_indices_shards_docs_deleted                             | gauge     | 3           | Count of deleted documents on each shard
 | elasticsearch_indices_store_size_bytes                                | gauge     | 1           | Current size of stored index data in bytes

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Further Information
 | elasticsearch_indices_segments_memory_bytes                           | gauge     | 1           | Current memory size of segments in bytes
 | elasticsearch_indices_settings_stats_read_only_indices                | gauge     | 1           | Count of indices that have read_only_allow_delete=true
 | elasticsearch_indices_settings_total_fields                           | gauge     |             | Index setting value for index.mapping.total_fields.limit (total allowable mapped fields in a index)
-| elasticsearch_indices_settings_number_of_replicas                     | gauge     |             | Index setting value for index.number_of_replicas
+| elasticsearch_indices_settings_replicas                     | gauge     |             | Index setting value for index.replicas
 | elasticsearch_indices_shards_docs                                     | gauge     | 3           | Count of documents on this shard
 | elasticsearch_indices_shards_docs_deleted                             | gauge     | 3           | Count of deleted documents on each shard
 | elasticsearch_indices_store_size_bytes                                | gauge     | 1           | Current size of stored index data in bytes

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -93,7 +93,7 @@ func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *I
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "indices_settings", "number_of_replicas"),
+					prometheus.BuildFQName(namespace, "indices_settings", "replicas"),
 					"index setting number_of_replicas",
 					defaultIndicesTotalFieldsLabels, nil,
 				),

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -90,6 +90,21 @@ func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *I
 					return val
 				},
 			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices_settings", "number_of_replicas"),
+					"index setting number_of_replicas",
+					defaultIndicesTotalFieldsLabels, nil,
+				),
+				Value: func(indexSettings Settings) float64 {
+					val, err := strconv.ParseFloat(indexSettings.IndexInfo.NumberOfReplicas, 64)
+					if err != nil {
+						return float64(defaultTotalFieldsValue)
+					}
+					return val
+				},
+			},
 		},
 	}
 }

--- a/collector/indices_settings_response.go
+++ b/collector/indices_settings_response.go
@@ -28,8 +28,9 @@ type Settings struct {
 
 // IndexInfo defines the blocks of the current index
 type IndexInfo struct {
-	Blocks  Blocks  `json:"blocks"`
-	Mapping Mapping `json:"mapping"`
+	Blocks           Blocks  `json:"blocks"`
+	Mapping          Mapping `json:"mapping"`
+	NumberOfReplicas string  `json:"number_of_replicas"`
 }
 
 // Blocks defines whether current index has read_only_allow_delete enabled


### PR DESCRIPTION
motivation: hunting for indices with `number_of_replicas` being set to zero, which might cause data loss in certain scenarios, need this metric to configure alert

output will be:

```
# HELP elasticsearch_indices_settings_number_of_replicas index setting number_of_replicas
# TYPE elasticsearch_indices_settings_number_of_replicas gauge
elasticsearch_indices_settings_number_of_replicas{index="foo"} 3
elasticsearch_indices_settings_number_of_replicas{index="bar"} 0
```

closes #482