### PR TITLE
Add search_query_current and indexing_index_current

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Further Information
 | elasticsearch_indices_active_queries                                  | gauge     | 1           | The number of currently active queries
 | elasticsearch_indices_docs                                            | gauge     | 1           | Count of documents on this node
 | elasticsearch_indices_docs_deleted                                    | gauge     | 1           | Count of deleted documents on this node
-| elasticsearch_indices_docs_indexed                                    | gauge     | 1           | The number of documents currently being indexed to an index
 | elasticsearch_indices_docs_primary                                    | gauge     |             | Count of documents with only primary shards on all nodes
 | elasticsearch_indices_fielddata_evictions                             | counter   | 1           | Evictions from field data
 | elasticsearch_indices_fielddata_memory_size_bytes                     | gauge     | 1           | Field data cache memory usage in bytes
@@ -135,6 +134,7 @@ Further Information
 | elasticsearch_indices_get_total                                       | counter   | 1           | Total get
 | elasticsearch_indices_indexing_delete_time_seconds_total              | counter   | 1           | Total time indexing delete in seconds
 | elasticsearch_indices_indexing_delete_total                           | counter   | 1           | Total indexing deletes
+| elasticsearch_indices_index_current                                   | gauge     | 1           | The number of documents currently being indexed to an index
 | elasticsearch_indices_indexing_index_time_seconds_total               | counter   | 1           | Cumulative index time in seconds
 | elasticsearch_indices_indexing_index_total                            | counter   | 1           | Total index calls
 | elasticsearch_indices_mappings_stats_fields                           | gauge     | 1           | Count of fields currently mapped by index

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -614,7 +614,7 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "index_stats", "docs_indexed"),
+					prometheus.BuildFQName(namespace, "index_stats", "index_current"),
 					"The number of documents currently being indexed to an index",
 					indexLabels.keys(), nil,
 				),


### PR DESCRIPTION
Signed-off-by: Loc Mai <lmai@axon.com>

We are missing these 2 important metrics for our ES clusters:

```
indexing_index_current
search_query_current
```