### PR TITLE
Update process CPU metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Further Information
 | elasticsearch_os_load5                                                | gauge     | 1           | Midterm load average
 | elasticsearch_os_load15                                               | gauge     | 1           | Longterm load average
 | elasticsearch_process_cpu_percent                                     | gauge     | 1           | Percent CPU used by process
-| elasticsearch_process_cpu_time_seconds_sum                            | counter   | 3           | Process CPU time in seconds
+| elasticsearch_process_cpu_seconds_total                               | counter   | 1           | Process CPU time in seconds
 | elasticsearch_process_mem_resident_size_bytes                         | gauge     | 1           | Resident memory in use by process in bytes
 | elasticsearch_process_mem_share_size_bytes                            | gauge     | 1           | Shared memory in use by process in bytes
 | elasticsearch_process_mem_virtual_size_bytes                          | gauge     | 1           | Total virtual memory used in bytes

--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1437,15 +1437,15 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.CounterValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "process", "cpu_time_seconds_sum"),
+					prometheus.BuildFQName(namespace, "process", "cpu_seconds_total"),
 					"Process CPU time in seconds",
-					append(defaultNodeLabels, "type"), nil,
+					defaultNodeLabels, nil,
 				),
 				Value: func(node NodeStatsNodeResponse) float64 {
 					return float64(node.Process.CPU.Total) / 1000
 				},
 				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
-					return append(defaultNodeLabelValues(cluster, node), "total")
+					return defaultNodeLabelValues(cluster, node)
 				},
 			},
 			{


### PR DESCRIPTION
With PR #498, we only have one process CPU metric.
* Drop the label.
* Update the name to match Prometheus naming.

Signed-off-by: SuperQ <superq@gmail.com>