### PR TITLE
Add elasticsearch_jvm_uptime gauge

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -1365,6 +1365,20 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "jvm", "uptime_seconds"),
+					"JVM process uptime in seconds",
+					append(defaultNodeLabels, "type"), nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.JVM.Uptime) / 1000
+				},
+				Labels: func(cluster string, node NodeStatsNodeResponse) []string {
+					return append(defaultNodeLabelValues(cluster, node), "mapped")
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "process", "cpu_percent"),
 					"Percent CPU used by process",
 					defaultNodeLabels, nil,

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -15,7 +15,7 @@ package collector
 
 import "encoding/json"
 
-// nodeStatsResponse is a representation of a Elasticsearch Node Stats
+// nodeStatsResponse is a representation of an Elasticsearch Node Stats
 type nodeStatsResponse struct {
 	ClusterName string `json:"cluster_name"`
 	Nodes       map[string]NodeStatsNodeResponse
@@ -55,6 +55,7 @@ type NodeStatsJVMResponse struct {
 	BufferPools map[string]NodeStatsJVMBufferPoolResponse `json:"buffer_pools"`
 	GC          NodeStatsJVMGCResponse                    `json:"gc"`
 	Mem         NodeStatsJVMMemResponse                   `json:"mem"`
+	Uptime      int64                                     `json:"uptime_in_millis"`
 }
 
 // NodeStatsJVMGCResponse defines node stats JVM garbage collector information structure


### PR DESCRIPTION
I discovered that the the JVM uptime (readily available in the http://localhost:9200/_nodes/stats output) wasn't included in the output returned by the exporter. This PR adds it.

Tested locally with an ES 7.10.2 instance.