### PR TITLE
Add Indices filter flag

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1106,6 +1106,9 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 
 	u := *i.url
 	indicesStatsQueryPath := fmt.Sprintf("/%s/_stats", i.indicesFilter)
+	_ = level.Debug(i.logger).Log(
+		"msg", fmt.Sprintf("indices fetch query path: %s", indicesStatsQueryPath),
+	)
 	u.Path = path.Join(u.Path, indicesStatsQueryPath)
 	if i.shards {
 		u.RawQuery = "ignore_unavailable=true&level=shards"

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1170,9 +1170,6 @@ func (i *Indices) fetchAndDecodeAliases() (aliasesResponse, error) {
 }
 
 func (i *Indices) queryURL(u *url.URL) ([]byte, error) {
-	_ = level.Info(i.logger).Log(
-		"msg", fmt.Sprintf("query url: %s", u.String()),
-	)
 	res, err := i.client.Get(u.String())
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to get resource from %s://%s:%s%s: %s",

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -59,6 +59,7 @@ type Indices struct {
 	logger          log.Logger
 	client          *http.Client
 	url             *url.URL
+	indicesFilter   string
 	shards          bool
 	aliases         bool
 	clusterInfoCh   chan *clusterinfo.Response
@@ -74,7 +75,7 @@ type Indices struct {
 }
 
 // NewIndices defines Indices Prometheus metrics
-func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool, includeAliases bool) *Indices {
+func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards bool, includeAliases bool, indicesFilter string) *Indices {
 
 	indexLabels := labels{
 		keys: func(...string) []string {
@@ -122,6 +123,7 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 		logger:        logger,
 		client:        client,
 		url:           url,
+		indicesFilter: indicesFilter,
 		shards:        shards,
 		aliases:       includeAliases,
 		clusterInfoCh: make(chan *clusterinfo.Response),
@@ -1102,7 +1104,8 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 	var isr indexStatsResponse
 
 	u := *i.url
-	u.Path = path.Join(u.Path, "/_all/_stats")
+	indicesStatsQueryPath = fmt.Sprintf("/%s/_stats", i.indicesFilter)
+	u.Path = path.Join(u.Path, indicesStatsQueryPath)
 	if i.shards {
 		u.RawQuery = "ignore_unavailable=true&level=shards"
 	} else {

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -16,16 +16,17 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/prometheus-community/elasticsearch_exporter/pkg/clusterinfo"
-	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 	"sort"
 	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/elasticsearch_exporter/pkg/clusterinfo"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type labels struct {
@@ -1104,7 +1105,7 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 	var isr indexStatsResponse
 
 	u := *i.url
-	indicesStatsQueryPath = fmt.Sprintf("/%s/_stats", i.indicesFilter)
+	indicesStatsQueryPath := fmt.Sprintf("/%s/_stats", i.indicesFilter)
 	u.Path = path.Join(u.Path, indicesStatsQueryPath)
 	if i.shards {
 		u.RawQuery = "ignore_unavailable=true&level=shards"

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1106,9 +1106,6 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 
 	u := *i.url
 	indicesStatsQueryPath := fmt.Sprintf("/%s/_stats", i.indicesFilter)
-	_ = level.Debug(i.logger).Log(
-		"msg", fmt.Sprintf("indices fetch query path: %s", indicesStatsQueryPath),
-	)
 	u.Path = path.Join(u.Path, indicesStatsQueryPath)
 	if i.shards {
 		u.RawQuery = "ignore_unavailable=true&level=shards"

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1170,6 +1170,9 @@ func (i *Indices) fetchAndDecodeAliases() (aliasesResponse, error) {
 }
 
 func (i *Indices) queryURL(u *url.URL) ([]byte, error) {
+	_ = level.Info(i.logger).Log(
+		"msg", fmt.Sprintf("query url: %s", u.String()),
+	)
 	res, err := i.client.Get(u.String())
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to get resource from %s://%s:%s%s: %s",

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1106,7 +1106,7 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 
 	u := *i.url
 	indicesStatsQueryPath := fmt.Sprintf("/%s/_stats", i.indicesFilter)
-	_ = level.Info(i.logger).Log(
+	_ = level.Debug(i.logger).Log(
 		"msg", fmt.Sprintf("indices fetch query path: %s", indicesStatsQueryPath),
 	)
 	u.Path = path.Join(u.Path, indicesStatsQueryPath)

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -1106,7 +1106,7 @@ func (i *Indices) fetchAndDecodeIndexStats() (indexStatsResponse, error) {
 
 	u := *i.url
 	indicesStatsQueryPath := fmt.Sprintf("/%s/_stats", i.indicesFilter)
-	_ = level.Debug(i.logger).Log(
+	_ = level.Info(i.logger).Log(
 		"msg", fmt.Sprintf("indices fetch query path: %s", indicesStatsQueryPath),
 	)
 	u.Path = path.Join(u.Path, indicesStatsQueryPath)

--- a/collector/indices_mappings.go
+++ b/collector/indices_mappings.go
@@ -157,7 +157,7 @@ func (im *IndicesMappings) getAndParseURL(u *url.URL) (*IndicesMappingsResponse,
 
 func (im *IndicesMappings) fetchAndDecodeIndicesMappings() (*IndicesMappingsResponse, error) {
 	u := *im.url
-	indicesMappingsQueryPath = fmt.Sprintf("/%s/_mappings", im.indicesFilter)
+	indicesMappingsQueryPath := fmt.Sprintf("/%s/_mappings", im.indicesFilter)
 	u.Path = path.Join(u.Path, indicesMappingsQueryPath)
 	return im.getAndParseURL(&u)
 }

--- a/collector/indices_mappings.go
+++ b/collector/indices_mappings.go
@@ -38,9 +38,10 @@ type indicesMappingsMetric struct {
 
 // IndicesMappings information struct
 type IndicesMappings struct {
-	logger log.Logger
-	client *http.Client
-	url    *url.URL
+	logger        log.Logger
+	client        *http.Client
+	url           *url.URL
+	indicesFilter string
 
 	up                              prometheus.Gauge
 	totalScrapes, jsonParseFailures prometheus.Counter
@@ -49,13 +50,14 @@ type IndicesMappings struct {
 }
 
 // NewIndicesMappings defines Indices IndexMappings Prometheus metrics
-func NewIndicesMappings(logger log.Logger, client *http.Client, url *url.URL) *IndicesMappings {
+func NewIndicesMappings(logger log.Logger, client *http.Client, url *url.URL, indicesFilter string) *IndicesMappings {
 	subsystem := "indices_mappings_stats"
 
 	return &IndicesMappings{
-		logger: logger,
-		client: client,
-		url:    url,
+		logger:        logger,
+		client:        client,
+		url:           url,
+		indicesFilter: indicesFilter,
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, subsystem, "up"),
@@ -155,7 +157,8 @@ func (im *IndicesMappings) getAndParseURL(u *url.URL) (*IndicesMappingsResponse,
 
 func (im *IndicesMappings) fetchAndDecodeIndicesMappings() (*IndicesMappingsResponse, error) {
 	u := *im.url
-	u.Path = path.Join(u.Path, "/_all/_mappings")
+	indicesMappingsQueryPath = fmt.Sprintf("/%s/_mappings", im.indicesFilter)
+	u.Path = path.Join(u.Path, indicesMappingsQueryPath)
 	return im.getAndParseURL(&u)
 }
 

--- a/collector/indices_mappings_test.go
+++ b/collector/indices_mappings_test.go
@@ -124,7 +124,7 @@ func TestMapping(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewIndicesMappings(log.NewNopLogger(), http.DefaultClient, u)
+			c := NewIndicesMappings(log.NewNopLogger(), http.DefaultClient, u, "_all")
 			imr, err := c.fetchAndDecodeIndicesMappings()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode indices mappings: %s", err)

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -29,10 +29,10 @@ import (
 
 // IndicesSettings information struct
 type IndicesSettings struct {
-	logger          log.Logger
-	client          *http.Client
-	url             *url.URL
-	indicesFilter   string
+	logger        log.Logger
+	client        *http.Client
+	url           *url.URL
+	indicesFilter string
 
 	up              prometheus.Gauge
 	readOnlyIndices prometheus.Gauge
@@ -141,7 +141,7 @@ func (cs *IndicesSettings) getAndParseURL(u *url.URL, data interface{}) error {
 func (cs *IndicesSettings) fetchAndDecodeIndicesSettings() (IndicesSettingsResponse, error) {
 
 	u := *cs.url
-	indicesSettingsQueryPath = fmt.Sprintf("/%s/_settings", cs.indicesFilter)
+	indicesSettingsQueryPath := fmt.Sprintf("/%s/_settings", cs.indicesFilter)
 	u.Path = path.Join(u.Path, indicesSettingsQueryPath)
 	var asr IndicesSettingsResponse
 	err := cs.getAndParseURL(&u, &asr)

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -29,9 +29,10 @@ import (
 
 // IndicesSettings information struct
 type IndicesSettings struct {
-	logger log.Logger
-	client *http.Client
-	url    *url.URL
+	logger          log.Logger
+	client          *http.Client
+	url             *url.URL
+	indicesFilter   string
 
 	up              prometheus.Gauge
 	readOnlyIndices prometheus.Gauge
@@ -52,11 +53,12 @@ type indicesSettingsMetric struct {
 }
 
 // NewIndicesSettings defines Indices Settings Prometheus metrics
-func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *IndicesSettings {
+func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL, indicesFilter string) *IndicesSettings {
 	return &IndicesSettings{
-		logger: logger,
-		client: client,
-		url:    url,
+		logger:        logger,
+		client:        client,
+		url:           url,
+		indicesFilter: indicesFilter,
 
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, "indices_settings_stats", "up"),
@@ -139,7 +141,8 @@ func (cs *IndicesSettings) getAndParseURL(u *url.URL, data interface{}) error {
 func (cs *IndicesSettings) fetchAndDecodeIndicesSettings() (IndicesSettingsResponse, error) {
 
 	u := *cs.url
-	u.Path = path.Join(u.Path, "/_all/_settings")
+	indicesSettingsQueryPath = fmt.Sprintf("/%s/_settings", cs.indicesFilter)
+	u.Path = path.Join(u.Path, indicesSettingsQueryPath)
 	var asr IndicesSettingsResponse
 	err := cs.getAndParseURL(&u, &asr)
 	if err != nil {

--- a/collector/indices_settings_test.go
+++ b/collector/indices_settings_test.go
@@ -70,7 +70,7 @@ func TestIndicesSettings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse URL: %s", err)
 			}
-			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u)
+			c := NewIndicesSettings(log.NewNopLogger(), http.DefaultClient, u, "_all")
 			nsr, err := c.fetchAndDecodeIndicesSettings()
 			if err != nil {
 				t.Fatalf("Failed to fetch or decode indices settings: %s", err)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -49,7 +49,7 @@ func TestIndices(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, false)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, false, "_all")
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -123,7 +123,7 @@ func TestAliases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to parse URL: %s", err)
 		}
-		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, true)
+		i := NewIndices(log.NewNopLogger(), http.DefaultClient, u, false, true, "_all")
 		stats, err := i.fetchAndDecodeIndexStats()
 		if err != nil {
 			t.Fatalf("Failed to fetch or decode indices stats: %s", err)

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ func main() {
 		esExportSLM = kingpin.Flag("es.slm",
 			"Export stats for SLM snapshots.").
 			Default("false").Bool()
+		esIndicesFilter = kingpin.Flag("es.indices_filter",
+			"Indices filter by name for which metrics should be exposed, using prefix with wildcards and/or commas as multi-selection delimiter.").
+			Default("_all").String()
 		esClusterInfoInterval = kingpin.Flag("es.clusterinfo.interval",
 			"Cluster info update interval for the cluster label").
 			Default("5m").Duration()
@@ -185,7 +188,7 @@ func main() {
 
 	if *esExportIndices || *esExportShards {
 		prometheus.MustRegister(collector.NewShards(logger, httpClient, esURL))
-		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndexAliases)
+		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndexAliases, *esIndicesFilter)
 		prometheus.MustRegister(iC)
 		if registerErr := clusterInfoRetriever.RegisterConsumer(iC); registerErr != nil {
 			_ = level.Error(logger).Log("msg", "failed to register indices collector in cluster info")
@@ -206,7 +209,7 @@ func main() {
 	}
 
 	if *esExportIndicesSettings {
-		prometheus.MustRegister(collector.NewIndicesSettings(logger, httpClient, esURL))
+		prometheus.MustRegister(collector.NewIndicesSettings(logger, httpClient, esURL, *esIndicesFilter))
 	}
 
 	if *esExportIndicesMappings {

--- a/main.go
+++ b/main.go
@@ -190,9 +190,6 @@ func main() {
 		prometheus.MustRegister(collector.NewShards(logger, httpClient, esURL))
 		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndexAliases, *esIndicesFilter)
 		prometheus.MustRegister(iC)
-		_ = level.Info(logger).Log(
-			"msg", fmt.Sprintf("inside exExportIndices condition. filter : %s", *esIndicesFilter),
-		)
 		if registerErr := clusterInfoRetriever.RegisterConsumer(iC); registerErr != nil {
 			_ = level.Error(logger).Log("msg", "failed to register indices collector in cluster info")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -190,6 +190,9 @@ func main() {
 		prometheus.MustRegister(collector.NewShards(logger, httpClient, esURL))
 		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndexAliases, *esIndicesFilter)
 		prometheus.MustRegister(iC)
+		_ = level.Info(logger).Log(
+			"msg", fmt.Sprintf("inside exExportIndices condition. filter : %s", *esIndicesFilter),
+		)
 		if registerErr := clusterInfoRetriever.RegisterConsumer(iC); registerErr != nil {
 			_ = level.Error(logger).Log("msg", "failed to register indices collector in cluster info")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -189,10 +189,6 @@ func main() {
 	if *esExportIndices || *esExportShards {
 		prometheus.MustRegister(collector.NewShards(logger, httpClient, esURL))
 		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndexAliases, *esIndicesFilter)
-		_ = level.Debug(logger).Log(
-			"msg", fmt.Sprintf("indices filter flag has recieved: %s", *esIndicesFilter),
-			"addr", *listenAddress,
-		)
 		prometheus.MustRegister(iC)
 		if registerErr := clusterInfoRetriever.RegisterConsumer(iC); registerErr != nil {
 			_ = level.Error(logger).Log("msg", "failed to register indices collector in cluster info")

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func main() {
 	}
 
 	if *esExportIndicesMappings {
-		prometheus.MustRegister(collector.NewIndicesMappings(logger, httpClient, esURL))
+		prometheus.MustRegister(collector.NewIndicesMappings(logger, httpClient, esURL, *esIndicesFilter))
 	}
 
 	// create a http server

--- a/main.go
+++ b/main.go
@@ -189,6 +189,10 @@ func main() {
 	if *esExportIndices || *esExportShards {
 		prometheus.MustRegister(collector.NewShards(logger, httpClient, esURL))
 		iC := collector.NewIndices(logger, httpClient, esURL, *esExportShards, *esExportIndexAliases, *esIndicesFilter)
+		_ = level.Debug(logger).Log(
+			"msg", fmt.Sprintf("indices filter flag has recieved: %s", *esIndicesFilter),
+			"addr", *listenAddress,
+		)
 		prometheus.MustRegister(iC)
 		if registerErr := clusterInfoRetriever.RegisterConsumer(iC); registerErr != nil {
 			_ = level.Error(logger).Log("msg", "failed to register indices collector in cluster info")


### PR DESCRIPTION
As can be seen earlier, certain people asked for the option to filter the indices they are exporting.

Especially if you have a lot of them and you need to monitor just certain, the rest of it, is just a waste of resources.

ATM, fetching indices settings/stats/mappings queries all the existing ones using this kind of GET requests:
`GET /_all/_settings`, `GET /_all/_stats` and  `GET /_all/_mappings`

As mentioned in the docs:
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html

It's possible to just retrieve the ones which match 2 types of queries:

1. Matching using wildcard(*) expression. i.e:
`GET /prefix_*/_stats`

2. Matching a list of indices, using comma:
`GET /first_name,second_name/_stats`

It is possible to mix them both. ie:
`GET /prefix_1_*,prefix_2_*/_stats`

The new added flag:
`es.indices_filter` (default is '_all')

<strong>Note: The flag will be used only if any export indices flag is used.</strong>
To use it, pass an expression to match your use-case indices, default '_all' just like before.
By passing one of the options mentioned above as a value (statement with a wildcard, list with commas), it will be used in the http request to retrieve statistics.

This change would be very appreciated,
Thanks.
