### PR TITLE
Support Env var overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Below is the command line options summary:
 elasticsearch_exporter --help
 ```
 
+All the arguments can be provided through an enviroment variable. The convention is as follows. If the argument is `es.uri` the Envar becomes `EXPORTER_ES_URI`. `web.listen-address` becomes `EXPORTER_WEB_LISTEN_ADDRESS`
+
 | Argument                | Introduced in Version | Description | Default     |
 | --------                | --------------------- | ----------- | ----------- |
 | es.uri                  | 1.0.2                 | Address (host and port) of the Elasticsearch node we should connect to. This could be a local node (`localhost:9200`, for instance), or the address of a remote Elasticsearch server. When basic auth is needed, specify as: `<proto>://<user>:<password>@<host>:<port>`. E.G., `http://admin:pass@localhost:9200`. Special characters in the user credentials need to be URL-encoded. | http://localhost:9200 |

--- a/main.go
+++ b/main.go
@@ -45,78 +45,79 @@ func (t *transportWithAPIKey) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 func main() {
+	app := kingpin.New("exporter", "").DefaultEnvars()
 	var (
-		listenAddress = kingpin.Flag("web.listen-address",
+		listenAddress = app.Flag("web.listen-address",
 			"Address to listen on for web interface and telemetry.").
 			Default(":9114").String()
-		metricsPath = kingpin.Flag("web.telemetry-path",
+		metricsPath = app.Flag("web.telemetry-path",
 			"Path under which to expose metrics.").
 			Default("/metrics").String()
-		esURI = kingpin.Flag("es.uri",
+		esURI = app.Flag("es.uri",
 			"HTTP API address of an Elasticsearch node.").
 			Default("http://localhost:9200").String()
-		esTimeout = kingpin.Flag("es.timeout",
+		esTimeout = app.Flag("es.timeout",
 			"Timeout for trying to get stats from Elasticsearch.").
 			Default("5s").Duration()
-		esAllNodes = kingpin.Flag("es.all",
+		esAllNodes = app.Flag("es.all",
 			"Export stats for all nodes in the cluster. If used, this flag will override the flag es.node.").
 			Default("false").Bool()
-		esNode = kingpin.Flag("es.node",
+		esNode = app.Flag("es.node",
 			"Node's name of which metrics should be exposed.").
 			Default("_local").String()
-		esExportIndices = kingpin.Flag("es.indices",
+		esExportIndices = app.Flag("es.indices",
 			"Export stats for indices in the cluster.").
 			Default("false").Bool()
-		esExportIndicesSettings = kingpin.Flag("es.indices_settings",
+		esExportIndicesSettings = app.Flag("es.indices_settings",
 			"Export stats for settings of all indices of the cluster.").
 			Default("false").Bool()
-		esExportIndicesMappings = kingpin.Flag("es.indices_mappings",
+		esExportIndicesMappings = app.Flag("es.indices_mappings",
 			"Export stats for mappings of all indices of the cluster.").
 			Default("false").Bool()
-		esExportIndexAliases = kingpin.Flag("es.aliases",
+		esExportIndexAliases = app.Flag("es.aliases",
 			"Export informational alias metrics.").
 			Default("true").Bool()
-		esExportClusterSettings = kingpin.Flag("es.cluster_settings",
+		esExportClusterSettings = app.Flag("es.cluster_settings",
 			"Export stats for cluster settings.").
 			Default("false").Bool()
-		esExportShards = kingpin.Flag("es.shards",
+		esExportShards = app.Flag("es.shards",
 			"Export stats for shards in the cluster (implies --es.indices).").
 			Default("false").Bool()
-		esExportSnapshots = kingpin.Flag("es.snapshots",
+		esExportSnapshots = app.Flag("es.snapshots",
 			"Export stats for the cluster snapshots.").
 			Default("false").Bool()
-		esExportSLM = kingpin.Flag("es.slm",
+		esExportSLM = app.Flag("es.slm",
 			"Export stats for SLM snapshots.").
 			Default("false").Bool()
-		esClusterInfoInterval = kingpin.Flag("es.clusterinfo.interval",
+		esClusterInfoInterval = app.Flag("es.clusterinfo.interval",
 			"Cluster info update interval for the cluster label").
 			Default("5m").Duration()
-		esCA = kingpin.Flag("es.ca",
+		esCA = app.Flag("es.ca",
 			"Path to PEM file that contains trusted Certificate Authorities for the Elasticsearch connection.").
 			Default("").String()
-		esClientPrivateKey = kingpin.Flag("es.client-private-key",
+		esClientPrivateKey = app.Flag("es.client-private-key",
 			"Path to PEM file that contains the private key for client auth when connecting to Elasticsearch.").
 			Default("").String()
-		esClientCert = kingpin.Flag("es.client-cert",
+		esClientCert = app.Flag("es.client-cert",
 			"Path to PEM file that contains the corresponding cert for the private key to connect to Elasticsearch.").
 			Default("").String()
-		esInsecureSkipVerify = kingpin.Flag("es.ssl-skip-verify",
+		esInsecureSkipVerify = app.Flag("es.ssl-skip-verify",
 			"Skip SSL verification when connecting to Elasticsearch.").
 			Default("false").Bool()
-		logLevel = kingpin.Flag("log.level",
+		logLevel = app.Flag("log.level",
 			"Sets the loglevel. Valid levels are debug, info, warn, error").
 			Default("info").String()
-		logFormat = kingpin.Flag("log.format",
+		logFormat = app.Flag("log.format",
 			"Sets the log format. Valid formats are json and logfmt").
 			Default("logfmt").String()
-		logOutput = kingpin.Flag("log.output",
+		logOutput = app.Flag("log.output",
 			"Sets the log output. Valid outputs are stdout and stderr").
 			Default("stdout").String()
 	)
 
-	kingpin.Version(version.Print(name))
-	kingpin.CommandLine.HelpFlag.Short('h')
-	kingpin.Parse()
+	app.Version(version.Print(name))
+	app.CommandLine.HelpFlag.Short('h')
+	app.Parse()
 
 	logger := getLogger(*logLevel, *logOutput, *logFormat)
 


### PR DESCRIPTION
To ease configuration of the exporter running in K8s and other container environments, environmental variables provide an easier means to change configurations. 

kingpin already supports Envars.