### PR TITLE
Update to Go 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   # This must match .promu.yml.
   golang:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
 jobs:
   test:
     executor: golang

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     # This must match .circle/config.yml.
-    version: 1.18
+    version: 1.19
 repository:
     path: github.com/prometheus-community/elasticsearch_exporter
 build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/elasticsearch_exporter
 
-go 1.17
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.16.7


### PR DESCRIPTION
This bumps the Elasticsearch exporter to Go 1.19. I tried to find all places that reference either Go 1.17 or Go 1.18.

It seems like it would work just fine with the latest version. 