### PR TITLE
Fix naming for index search active queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Further Information
 | elasticsearch_filesystem_io_stats_device_write_operations_count       | gauge     | 1           | Count of disk write operations
 | elasticsearch_filesystem_io_stats_device_read_size_kilobytes_sum      | gauge     | 1           | Total kilobytes read from disk
 | elasticsearch_filesystem_io_stats_device_write_size_kilobytes_sum     | gauge     | 1           | Total kilobytes written to disk
-| elasticsearch_indices_active_queries                                  | gauge     | 1           | The number of currently active queries
+| elasticsearch_indices_search_active_queries                           | gauge     | 1           | The number of currently active search and suggest queries
 | elasticsearch_indices_docs                                            | gauge     | 1           | Count of documents on this node
 | elasticsearch_indices_docs_deleted                                    | gauge     | 1           | Count of deleted documents on this node
 | elasticsearch_indices_docs_primary                                    | gauge     |             | Count of documents with only primary shards on all nodes

--- a/collector/indices.go
+++ b/collector/indices.go
@@ -16,16 +16,17 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/prometheus-community/elasticsearch_exporter/pkg/clusterinfo"
-	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 	"sort"
 	"strconv"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus-community/elasticsearch_exporter/pkg/clusterinfo"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type labels struct {
@@ -518,8 +519,8 @@ func NewIndices(logger log.Logger, client *http.Client, url *url.URL, shards boo
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
-					prometheus.BuildFQName(namespace, "search", "active_queries"),
-					"The number of currently active queries",
+					prometheus.BuildFQName(namespace, "indices_search", "active_queries"),
+					"The number of currently active search and suggest queries",
 					indexLabels.keys(), nil,
 				),
 				Value: func(indexStats IndexStatsIndexResponse) float64 {


### PR DESCRIPTION
The README was wrong as noted in #640. Add the indices_ prefix to the subsystem since this is related to indices and update the README.

Signed-off-by: Joe Adams <github@joeadams.io>