### PR TITLE
Fix ilm metric labels (#677)

### DIFF
--- a/collector/ilm_status.go
+++ b/collector/ilm_status.go
@@ -79,7 +79,7 @@ func NewIlmStatus(logger log.Logger, client *http.Client, url *url.URL) *IlmStat
 			Desc: prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, subsystem, "status"),
 				"Current status of ilm. Status can be STOPPED, RUNNING, STOPPING.",
-				ilmStatuses, nil,
+				[]string{"operation_mode"}, nil,
 			),
 			Value: func(ilm *IlmStatusResponse, status string) float64 {
 				if ilm.OperationMode == status {


### PR DESCRIPTION
The metric labels in the prometheus description were set to all 3 status options, instead of the name of the status label. The code exports a metric for each of the statuses individually, not all 3 at the same time.

fixes #677