### PR TITLE
fix: comment typo error

### DIFF
--- a/pkg/clusterinfo/clusterinfo.go
+++ b/pkg/clusterinfo/clusterinfo.go
@@ -49,7 +49,7 @@ type consumer interface {
 	String() string
 }
 
-// Retriever periodically gets the cluster info from the / endpoint end
+// Retriever periodically gets the cluster info from the / endpoint and
 // sends it to all registered consumer channels
 type Retriever struct {
 	consumerChannels      map[string]*chan *Response


### PR DESCRIPTION
There is an typo error in Retriever struct comments in the clusterinfo package.