### PR TITLE
fix: set the value of elasticsearch_clusterinfo_version_info to 1

### DIFF
--- a/pkg/clusterinfo/clusterinfo.go
+++ b/pkg/clusterinfo/clusterinfo.go
@@ -146,7 +146,7 @@ func (r *Retriever) updateMetrics(res *Response) {
 		res.Version.BuildHash,
 		res.Version.Number.String(),
 		res.Version.LuceneVersion.String(),
-	)
+	).Set(1.0)
 	r.lastUpstreamSuccessTs.WithLabelValues(url).Set(float64(time.Now().Unix()))
 }
 


### PR DESCRIPTION
In the Prometheus ecosystem, info-style metrics (those with the `_info` suffix) usually have a value of 1. Although not enforced, this has become a [standard pattern across Prometheus](https://www.robustperception.io/why-info-style-metrics-have-a-value-of-1/) and the exporters (see `prometheus_build_info`).

`elasticsearch_clusterinfo_version_info` is a natural metric to be joined with when we want to, for instance, get the `cluster` label in a metric that doesn't provide it by default:

```
  elasticsearch_clustersettings_stats_max_shards_per_node
* on (instance) group_left (cluster)
  (elasticsearch_clusterinfo_version_info)
```

> There are ways of working around the `0` value of the metric at query time, like adding `1` if we are multiplying or (if possible) using the addition operator.