### PR TITLE
Make translog_size_in_bytes a gauge

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -514,7 +514,7 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 				Labels: defaultNodeLabelValues,
 			},
 			{
-				Type: prometheus.CounterValue,
+				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "translog_size_in_bytes"),
 					"Total translog size in bytes",


### PR DESCRIPTION
Grafana (and probably other tools) likes to encourage you to take rates of counters. However, In this case, it's invalid; translog_size_in_bytes does not only go up.

![image](https://github.com/prometheus-community/elasticsearch_exporter/assets/1924007/c5d257d9-c387-4e59-bf0f-82c5f6efa84f)

Using rate on this metric will likely lead to very wrong dashboards. [rate() documentation](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) includes a note: "rate should only be used with counters and native histograms where the components behave like counters"

I didn't check if other metrics have this property. Maybe there should be some effort to remove any instances where this happens?

----

I made this change with the github editor (because it's so minor) but that means I haven't run any tests. Is that OK?