### PR TITLE
Add extra tests and improve error handling in watermark metrics

### DIFF
--- a/collector/cluster_settings_test.go
+++ b/collector/cluster_settings_test.go
@@ -60,9 +60,6 @@ elasticsearch_clustersettings_stats_shard_allocation_enabled 0
 # HELP elasticsearch_clustersettings_allocation_threshold_enabled Is disk allocation decider enabled.
 # TYPE elasticsearch_clustersettings_allocation_threshold_enabled gauge
 elasticsearch_clustersettings_allocation_threshold_enabled 1
-# HELP elasticsearch_clustersettings_allocation_watermark_flood_stage_ratio Flood stage watermark as a ratio.
-# TYPE elasticsearch_clustersettings_allocation_watermark_flood_stage_ratio gauge
-elasticsearch_clustersettings_allocation_watermark_flood_stage_ratio 0
 # HELP elasticsearch_clustersettings_allocation_watermark_high_ratio High watermark for disk usage as a ratio.
 # TYPE elasticsearch_clustersettings_allocation_watermark_high_ratio gauge
 elasticsearch_clustersettings_allocation_watermark_high_ratio 0.9
@@ -82,15 +79,6 @@ elasticsearch_clustersettings_stats_shard_allocation_enabled 0
 # HELP elasticsearch_clustersettings_allocation_threshold_enabled Is disk allocation decider enabled.
 # TYPE elasticsearch_clustersettings_allocation_threshold_enabled gauge
 elasticsearch_clustersettings_allocation_threshold_enabled 0
-# HELP elasticsearch_clustersettings_allocation_watermark_flood_stage_ratio Flood stage watermark as a ratio.
-# TYPE elasticsearch_clustersettings_allocation_watermark_flood_stage_ratio gauge
-elasticsearch_clustersettings_allocation_watermark_flood_stage_ratio 0
-# HELP elasticsearch_clustersettings_allocation_watermark_high_ratio High watermark for disk usage as a ratio.
-# TYPE elasticsearch_clustersettings_allocation_watermark_high_ratio gauge
-elasticsearch_clustersettings_allocation_watermark_high_ratio 0
-# HELP elasticsearch_clustersettings_allocation_watermark_low_ratio Low watermark for disk usage as a ratio.
-# TYPE elasticsearch_clustersettings_allocation_watermark_low_ratio gauge
-elasticsearch_clustersettings_allocation_watermark_low_ratio 0
 `,
 		},
 		{
@@ -168,6 +156,60 @@ elasticsearch_clustersettings_allocation_watermark_low_bytes 5.24288e+07
 
 			if err := testutil.CollectAndCompare(wrapCollector{c}, strings.NewReader(tt.want)); err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func Test_getValueInBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    float64
+		wantErr bool
+	}{
+		{name: "Bytes", input: "100b", want: 100},
+		{name: "Kibibytes", input: "200kb", want: 204800},
+		{name: "Mebibytes", input: "300mb", want: 314572800},
+		{name: "Gibibytes", input: "400gb", want: 429496729600},
+		{name: "Tebibytes", input: "500tb", want: 549755813888000},
+		{name: "Pebibytes", input: "600pb", want: 675539944105574400},
+		{name: "Unknown", input: "9ab", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getValueInBytes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getValueInBytes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got != tt.want {
+				t.Errorf("getValueInBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getValueAsRatio(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    float64
+		wantErr bool
+	}{
+		{name: "Ratio", input: "0.5", want: 0.5},
+		{name: "Percentage", input: "50%", want: 0.5},
+		{name: "Invalid", input: "500b", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getValueAsRatio(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getValueAsRatio() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got != tt.want {
+				t.Errorf("getValueAsRatio() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Improve the error handling for watermark metrics. When we have an error, do not report a 0 value for the metric.

Adds tests for parsing the ratio/percentage and the human readable bytes in watermark data.

Functionality originally added in #611