### PR TITLE
Refactor tests for ilm_indices

### DIFF
--- a/fixtures/ilm_indices/6.6.0.json
+++ b/fixtures/ilm_indices/6.6.0.json
@@ -1,0 +1,20 @@
+{
+  "indices": {
+    "twitter": {
+      "index": "twitter",
+      "managed": false
+    },
+    "facebook": {
+      "index": "facebook",
+      "managed": true,
+      "policy": "my_policy",
+      "lifecycle_date_millis": 1660799138565,
+      "phase": "new",
+      "phase_time_millis": 1660799138651,
+      "action": "complete",
+      "action_time_millis": 1660799138651,
+      "step": "complete",
+      "step_time_millis": 1660799138651
+    }
+  }
+}


### PR DESCRIPTION
- Remove up, totalScrapes, and jsonParseFailures metrics. They are not useful.
- Move fixtures to individual files
- Base tests on the metric output for better testing the expected output instead of the internals.