### PR TITLE
Refactor tests for ilm_status

### DIFF
--- a/fixtures/ilm_status/6.6.0.json
+++ b/fixtures/ilm_status/6.6.0.json
@@ -1,0 +1,3 @@
+{
+  "operation_mode": "RUNNING"
+}


### PR DESCRIPTION
- Remove up, totalScrapes, and jsonParseFailures metrics. They are not useful.
- Move fixtures to individual files
- Base tests on the metric output for better testing the expected output instead of the internals.