### PR TITLE
add `elasticsearch_indices_settings_shards ` metric doc (#806)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Further Information
 | elasticsearch_indices_settings_stats_read_only_indices               | gauge      | 1           | Count of indices that have read_only_allow_delete=true                                              |
 | elasticsearch_indices_settings_total_fields                          | gauge      |             | Index setting value for index.mapping.total_fields.limit (total allowable mapped fields in a index) |
 | elasticsearch_indices_settings_replicas                              | gauge      |             | Index setting value for index.replicas                                                              |
+| elasticsearch_indices_settings_shards                                | gauge      |             | Index setting value for index.shards                                                                |
 | elasticsearch_indices_shards_docs                                    | gauge      | 3           | Count of documents on this shard                                                                    |
 | elasticsearch_indices_shards_docs_deleted                            | gauge      | 3           | Count of deleted documents on each shard                                                            |
 | elasticsearch_indices_store_size_bytes                               | gauge      | 1           | Current size of stored index data in bytes                                                          |

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -105,6 +105,21 @@ func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *I
 					return val
 				},
 			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices_settings", "shards"),
+					"index setting number_of_shards",
+					defaultIndicesTotalFieldsLabels, nil,
+				),
+				Value: func(indexSettings Settings) float64 {
+					val, err := strconv.ParseFloat(indexSettings.IndexInfo.NumberOfShard, 64)
+					if err != nil {
+						return float64(defaultTotalFieldsValue)
+					}
+					return val
+				},
+			},
 		},
 	}
 }

--- a/collector/indices_settings_response.go
+++ b/collector/indices_settings_response.go
@@ -31,6 +31,7 @@ type IndexInfo struct {
 	Blocks           Blocks  `json:"blocks"`
 	Mapping          Mapping `json:"mapping"`
 	NumberOfReplicas string  `json:"number_of_replicas"`
+	NumberOfShard    string  `json:"number_of_shards"`
 }
 
 // Blocks defines whether current index has read_only_allow_delete enabled

--- a/collector/indices_settings_test.go
+++ b/collector/indices_settings_test.go
@@ -55,7 +55,7 @@ func TestIndicesSettings(t *testing.T) {
 	// curl http://localhost:9200/_all/_settings
 
 	tcs := map[string]string{
-		"6.5.4": `{"viber":{"settings":{"index":{"creation_date":"1618593207186","number_of_shards":"5","number_of_replicas":"1","uuid":"lWg86KTARzO3r7lELytT1Q","version":{"created":"6050499"},"provided_name":"viber"}}},"instagram":{"settings":{"index":{"mapping":{"total_fields":{"limit":"10000"}},"number_of_shards":"5","blocks":{"read_only_allow_delete":"true"},"provided_name":"instagram","creation_date":"1618593203353","number_of_replicas":"1","uuid":"msb6eG7aT8GmNe-a4oyVtQ","version":{"created":"6050499"}}}},"twitter":{"settings":{"index":{"number_of_shards":"5","blocks":{"read_only_allow_delete":"true"},"provided_name":"twitter","creation_date":"1618593193641","number_of_replicas":"1","uuid":"YRUT8t4aSkKsNmGl7K3y4Q","version":{"created":"6050499"}}}},"facebook":{"settings":{"index":{"creation_date":"1618593199101","number_of_shards":"5","number_of_replicas":"1","uuid":"trZhb_YOTV-RWKitTYw81A","version":{"created":"6050499"},"provided_name":"facebook"}}}}`,
+		"6.5.4": `{"viber":{"settings":{"index":{"creation_date":"1618593207186","number_of_shards":"3","number_of_replicas":"1","uuid":"lWg86KTARzO3r7lELytT1Q","version":{"created":"6050499"},"provided_name":"viber"}}},"instagram":{"settings":{"index":{"mapping":{"total_fields":{"limit":"10000"}},"number_of_shards":"5","blocks":{"read_only_allow_delete":"true"},"provided_name":"instagram","creation_date":"1618593203353","number_of_replicas":"1","uuid":"msb6eG7aT8GmNe-a4oyVtQ","version":{"created":"6050499"}}}},"twitter":{"settings":{"index":{"number_of_shards":"5","blocks":{"read_only_allow_delete":"true"},"provided_name":"twitter","creation_date":"1618593193641","number_of_replicas":"1","uuid":"YRUT8t4aSkKsNmGl7K3y4Q","version":{"created":"6050499"}}}},"facebook":{"settings":{"index":{"creation_date":"1618593199101","number_of_shards":"5","number_of_replicas":"1","uuid":"trZhb_YOTV-RWKitTYw81A","version":{"created":"6050499"},"provided_name":"facebook"}}}}`,
 	}
 	for ver, out := range tcs {
 		for hn, handler := range map[string]http.Handler{
@@ -81,6 +81,7 @@ func TestIndicesSettings(t *testing.T) {
 			// }
 			var counter int
 			var totalFields int
+			var shards int
 			for key, value := range nsr {
 				if value.Settings.IndexInfo.Blocks.ReadOnly == "true" {
 					counter++
@@ -94,12 +95,21 @@ func TestIndicesSettings(t *testing.T) {
 						t.Errorf("Expected 10000 total_fields only for  instagram")
 					}
 				}
+				if value.Settings.IndexInfo.NumberOfShard == "3" {
+					shards++
+					if key != "viber" {
+						t.Errorf("Expected 3 shard only for shards")
+					}
+				}
 			}
 			if counter != 2 {
 				t.Errorf("Wrong number of read_only indexes")
 			}
 			if totalFields != 1 {
 				t.Errorf(("Wrong number of total_fields found"))
+			}
+			if shards != 1 {
+				t.Errorf(("Wrong number of shards found"))
 			}
 		}
 	}


### PR DESCRIPTION
Add monitoring indicators for number_of_shards https://github.com/prometheus-community/elasticsearch_exporter/issues/806

Test Results
#HELP elasticsearch_indices_settings_shards index setting number_of_shards
#TYPE elasticsearch_indices_settings_shards gauge
elasticsearch_indices_settings_shards{index=".monitoring-es-7-2023.10.27"} 1
elasticsearch_indices_settings_shards{index=".monitoring-es-7-2023.10.28"} 1