### PR TITLE
Add creation_date metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Further Information
 | elasticsearch_indices_search_query_total                             | counter    | 1           | Total number of queries                                                                             |
 | elasticsearch_indices_segments_count                                 | gauge      | 1           | Count of index segments on this node                                                                |
 | elasticsearch_indices_segments_memory_bytes                          | gauge      | 1           | Current memory size of segments in bytes                                                            |
-| elasticsearch_indices_settings_creation_timestamp_seconds            | gauge      | 1           | Timestamp of the index creation                                                                     |
+| elasticsearch_indices_settings_creation_timestamp_seconds            | gauge      | 1           | Timestamp of the index creation in seconds                                                                     |
 | elasticsearch_indices_settings_stats_read_only_indices               | gauge      | 1           | Count of indices that have read_only_allow_delete=true                                              |
 | elasticsearch_indices_settings_total_fields                          | gauge      |             | Index setting value for index.mapping.total_fields.limit (total allowable mapped fields in a index) |
 | elasticsearch_indices_settings_replicas                              | gauge      |             | Index setting value for index.replicas                                                              |

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Further Information
 | elasticsearch_indices_search_query_total                             | counter    | 1           | Total number of queries                                                                             |
 | elasticsearch_indices_segments_count                                 | gauge      | 1           | Count of index segments on this node                                                                |
 | elasticsearch_indices_segments_memory_bytes                          | gauge      | 1           | Current memory size of segments in bytes                                                            |
+| elasticsearch_indices_settings_creation_timestamp_seconds            | gauge      | 1           | Timestamp of the index creation                                                                     |
 | elasticsearch_indices_settings_stats_read_only_indices               | gauge      | 1           | Count of indices that have read_only_allow_delete=true                                              |
 | elasticsearch_indices_settings_total_fields                          | gauge      |             | Index setting value for index.mapping.total_fields.limit (total allowable mapped fields in a index) |
 | elasticsearch_indices_settings_replicas                              | gauge      |             | Index setting value for index.replicas                                                              |

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -118,7 +118,7 @@ func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *I
 					if err != nil {
 						return float64(defaultDateCreation)
 					}
-					return val/1000.0
+					return val / 1000.0
 				},
 			},
 		},

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -43,6 +43,7 @@ type IndicesSettings struct {
 var (
 	defaultIndicesTotalFieldsLabels = []string{"index"}
 	defaultTotalFieldsValue         = 1000 //es default configuration for total fields
+	defaultDateCreation             = 0    //es index default creation date
 )
 
 type indicesSettingsMetric struct {
@@ -101,6 +102,21 @@ func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *I
 					val, err := strconv.ParseFloat(indexSettings.IndexInfo.NumberOfReplicas, 64)
 					if err != nil {
 						return float64(defaultTotalFieldsValue)
+					}
+					return val
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices_settings", "creation_timestamp_seconds"),
+					"index setting creation_date",
+					defaultIndicesTotalFieldsLabels, nil,
+				),
+				Value: func(indexSettings Settings) float64 {
+					val, err := strconv.ParseFloat(indexSettings.IndexInfo.CreationDate, 64)
+					if err != nil {
+						return float64(defaultDateCreation)
 					}
 					return val
 				},

--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -118,7 +118,7 @@ func NewIndicesSettings(logger log.Logger, client *http.Client, url *url.URL) *I
 					if err != nil {
 						return float64(defaultDateCreation)
 					}
-					return val
+					return val/1000.0
 				},
 			},
 		},

--- a/collector/indices_settings_response.go
+++ b/collector/indices_settings_response.go
@@ -31,6 +31,7 @@ type IndexInfo struct {
 	Blocks           Blocks  `json:"blocks"`
 	Mapping          Mapping `json:"mapping"`
 	NumberOfReplicas string  `json:"number_of_replicas"`
+	CreationDate     string  `json:"creation_date"`
 }
 
 // Blocks defines whether current index has read_only_allow_delete enabled


### PR DESCRIPTION
Hello,

This PR has the purpose to add a new metrics :
`elasticsearch_indices_settings_creation_timestamp_seconds`

The motivation was that we want to keep tracks of the index creation dates. We compare it with log timestamp and create an alert if logs are timestamped in the future or in the past