### PR TITLE
Update Go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   # This must match .promu.yml.
   golang:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.21
 jobs:
   test:
     executor: golang

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,12 +1,11 @@
 go:
     # This must match .circle/config.yml.
-    version: 1.20
+    version: 1.21
 repository:
     path: github.com/prometheus-community/elasticsearch_exporter
 build:
     binaries:
         - name: elasticsearch_exporter
-    flags: -a -tags netgo
     ldflags: |
         -s
         -X github.com/prometheus/common/version.Version={{.Version}}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/elasticsearch_exporter
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2


### PR DESCRIPTION
* Update Go to 1.21.
* Update minimum Go to 1.20.
* Remove obsolete Go flag overrides.