### PR TITLE
[Feat] Add http request meta information to elasticsearch exporter for service management.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.4
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-kit/log v0.2.1
+	github.com/google/uuid v1.6.0
 	github.com/imdario/mergo v0.3.13
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=


### PR DESCRIPTION
- X-Opaque-Id:  

> The X-Opaque-Id header accepts any arbitrary value. However, we recommend you limit these values to a finite set, such as an ID per client. 

- x-request-from-head-app-name
> Used to record which application the request comes from

- x-request-path
> Used to record which route the request comes from

**Have a nice day**

![image](https://github.com/prometheus-community/elasticsearch_exporter/assets/3611274/33acee2c-a236-4943-9020-4aa5a4d16e48)