### PR TITLE
Add metrics to auto scale based on indexing pressure

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -96,7 +96,7 @@ var (
 	defaultRoleLabels               = []string{"cluster", "host", "name"}
 	defaultThreadPoolLabels         = append(defaultNodeLabels, "type")
 	defaultBreakerLabels            = append(defaultNodeLabels, "breaker")
-	defaultIndexingPressureLabels   = append(defaultNodeLabels, "indexing_pressure")
+	defaultIndexingPressureLabels   = []string{"cluster", "host", "name", "indexing_pressure"}
 	defaultFilesystemDataLabels     = append(defaultNodeLabels, "mount", "path")
 	defaultFilesystemIODeviceLabels = append(defaultNodeLabels, "device")
 	defaultCacheLabels              = append(defaultNodeLabels, "cache")
@@ -1628,7 +1628,12 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 					return float64(indexingPressureMem.Current.AllInBytes)
 				},
 				Labels: func(cluster string, node NodeStatsNodeResponse, indexingPressure string) []string {
-					return append(defaultNodeLabelValues(cluster, node), indexingPressure)
+					return []string{
+						cluster,
+						node.Host,
+						node.Name,
+						indexingPressure,
+					}
 				},
 			},
 			{
@@ -1642,7 +1647,12 @@ func NewNodes(logger log.Logger, client *http.Client, url *url.URL, all bool, no
 					return float64(indexingPressureStats.LimitInBytes)
 				},
 				Labels: func(cluster string, node NodeStatsNodeResponse, indexingPressure string) []string {
-					return append(defaultNodeLabelValues(cluster, node), indexingPressure)
+					return []string{
+						cluster,
+						node.Host,
+						node.Name,
+						indexingPressure,
+					}
 				},
 			},
 		},

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -23,23 +23,24 @@ type nodeStatsResponse struct {
 
 // NodeStatsNodeResponse defines node stats information structure for nodes
 type NodeStatsNodeResponse struct {
-	Name             string                                     `json:"name"`
-	Host             string                                     `json:"host"`
-	Timestamp        int64                                      `json:"timestamp"`
-	TransportAddress string                                     `json:"transport_address"`
-	Hostname         string                                     `json:"hostname"`
-	Roles            []string                                   `json:"roles"`
-	Attributes       map[string]string                          `json:"attributes"`
-	Indices          NodeStatsIndicesResponse                   `json:"indices"`
-	OS               NodeStatsOSResponse                        `json:"os"`
-	Network          NodeStatsNetworkResponse                   `json:"network"`
-	FS               NodeStatsFSResponse                        `json:"fs"`
-	ThreadPool       map[string]NodeStatsThreadPoolPoolResponse `json:"thread_pool"`
-	JVM              NodeStatsJVMResponse                       `json:"jvm"`
-	Breakers         map[string]NodeStatsBreakersResponse       `json:"breakers"`
-	HTTP             map[string]interface{}                     `json:"http"`
-	Transport        NodeStatsTransportResponse                 `json:"transport"`
-	Process          NodeStatsProcessResponse                   `json:"process"`
+	Name             string                                       `json:"name"`
+	Host             string                                       `json:"host"`
+	Timestamp        int64                                        `json:"timestamp"`
+	TransportAddress string                                       `json:"transport_address"`
+	Hostname         string                                       `json:"hostname"`
+	Roles            []string                                     `json:"roles"`
+	Attributes       map[string]string                            `json:"attributes"`
+	Indices          NodeStatsIndicesResponse                     `json:"indices"`
+	OS               NodeStatsOSResponse                          `json:"os"`
+	Network          NodeStatsNetworkResponse                     `json:"network"`
+	FS               NodeStatsFSResponse                          `json:"fs"`
+	ThreadPool       map[string]NodeStatsThreadPoolPoolResponse   `json:"thread_pool"`
+	JVM              NodeStatsJVMResponse                         `json:"jvm"`
+	Breakers         map[string]NodeStatsBreakersResponse         `json:"breakers"`
+	HTTP             map[string]interface{}                       `json:"http"`
+	Transport        NodeStatsTransportResponse                   `json:"transport"`
+	Process          NodeStatsProcessResponse                     `json:"process"`
+	IndexingPressure map[string]NodeStatsIndexingPressureResponse `json:"indexing_pressure"`
 }
 
 // NodeStatsBreakersResponse is a representation of a statistics about the field data circuit breaker
@@ -48,6 +49,17 @@ type NodeStatsBreakersResponse struct {
 	LimitSize     int64   `json:"limit_size_in_bytes"`
 	Overhead      float64 `json:"overhead"`
 	Tripped       int64   `json:"tripped"`
+}
+
+// NodeStatsIndexingPressureResponse is a representation of a elasticsearch indexing pressure
+type NodeStatsIndexingPressureResponse struct {
+	Current      NodeStatsIndexingPressureCurrentResponse `json:"current"`
+	LimitInBytes int64                                    `json:"limit_in_bytes"`
+}
+
+// NodeStatsIndexingPressureMemoryCurrentResponse is a representation of a elasticsearch indexing pressure current memory usage
+type NodeStatsIndexingPressureCurrentResponse struct {
+	AllInBytes int64 `json:"all_in_bytes"`
 }
 
 // NodeStatsJVMResponse is a representation of a JVM stats, memory pool information, garbage collection, buffer pools, number of loaded/unloaded classes


### PR DESCRIPTION
Add metrics indexing_pressure.memory.limit_in_bytes and indexing_pressure.memory.current.current.all_in_bytes to allow auto-scaling based on how close the cluster nodes are to dropping indexing requests due to the indexing request memory buffer reaching capacity.

This change may address the following two issues:

https://github.com/prometheus-community/elasticsearch_exporter/issues/638
https://github.com/prometheus-community/elasticsearch_exporter/issues/875

There is an open pull request from over a year ago attempting to address issue 638:

https://github.com/prometheus-community/elasticsearch_exporter/pull/727

In pull request 727 a large number of indexing_pressure related metrics are included in the code changes.  The comment chain indicates a concern that this could unnecessarily increase cardinality.  In this pull request we only add the two metrics required to address the need to auto-scale based on indexing pressure.

We (Telus Agriculture and Consumer Goods) have a production ES cluster that we are upgrading from v7 to v8.  As part of this upgrade the "elasticsearch_thread_pool_rejected_count" metric has been removed by the ES Dev Team because they switched from using a fixed length queue of indexing requests with a maximums size to using a memory buffer that defaults to 10% of available memory.  In the past, when the queue would reach capacity, the cluster would start rejecting indexing requests and you could auto-scale up the cluster to address that pressure.  Since the queue was eliminated we need a way to new way scale up based on indexing pressure so that we don't get behind on processing incoming requests.  Based on our investigation, the new way to do this is to compare the total size of the indexing memory buffer to the current used amount of buffer.  In this PR we add just the two metrics required to achieve auto scaling based on indexing pressure.