### PR TITLE
CVE-2024-24790: bump go to 1.22.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   # This must match .promu.yml.
   golang:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.22.6
 jobs:
   test:
     executor: golang

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     # This must match .circle/config.yml.
-    version: 1.21
+    version: 1.22
 repository:
     path: github.com/prometheus-community/elasticsearch_exporter
 build:


### PR DESCRIPTION
Fixes vulnerability [CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790) by updating Go to 1.22.6

Fixes #913 
