### PR TITLE
Add github actions workflow for testing PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,79 @@ jobs:
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
       - uses: ./.github/promci/actions/setup_environment
       - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
+
+  build:
+    name: Build Prometheus for common architectures
+    runs-on: ubuntu-latest
+    if: |
+      !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      &&
+      !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-'))
+      &&
+      !(github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2 ]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: ./.github/promci/actions/build
+        with:
+          promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
+          parallelism: 3
+          thread: ${{ matrix.thread }}
+
+  build_all:
+    name: Build Prometheus for all architectures
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      ||
+      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-'))
+      ||
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
+
+    # Whenever the Go version is updated here, .promu.yml
+    # should also be updated.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: ./.github/promci/actions/build
+        with:
+          parallelism: 12
+          thread: ${{ matrix.thread }}
+
+  publish_main:
+    name: Publish main branch artifacts
+    runs-on: ubuntu-latest
+    needs: [test_go, build_all]
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: ./.github/promci/actions/publish_main
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+
+  publish_release:
+    name: Publish release artefacts
+    runs-on: ubuntu-latest
+    needs: [test_go, build_all]
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: ./.github/promci/actions/publish_release
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+---
+name: CI
+on:
+  pull_request:
+  push:
+
+jobs:
+  test_go:
+    name: Go tests
+    runs-on: ubuntu-latest
+    container:
+      # Whenever the Go version is updated here, .promu.yml
+      # should also be updated.
+      image: quay.io/prometheus/golang-builder:1.23-base
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
+      - uses: ./.github/promci/actions/setup_environment
+      - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-'))
       &&
       !(github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+      &&
+      !(github.event_name == 'push' && github.event.ref == 'refs/heads/master')
     strategy:
       matrix:
         thread: [ 0, 1, 2 ]
@@ -48,6 +50,8 @@ jobs:
       (github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-'))
       ||
       (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+      ||
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
     strategy:
       matrix:
         thread: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
@@ -66,7 +70,10 @@ jobs:
     name: Publish main branch artifacts
     runs-on: ubuntu-latest
     needs: [test_go, build_all]
-    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+      ||
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5


### PR DESCRIPTION
This may need some more work because it's not always easy to test actions locally. After this runs well for all PRs and releases, I will remove the circleCI workflows. 