### PR TITLE
Fix github actions docker image org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           thread: ${{ matrix.thread }}
 
   publish_main:
+    # https://github.com/prometheus/promci/blob/52c7012f5f0070d7281b8db4a119e21341d43c91/actions/publish_main/action.yml
     name: Publish main branch artifacts
     runs-on: ubuntu-latest
     needs: [test_go, build_all]
@@ -79,8 +80,10 @@ jobs:
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
       - uses: ./.github/promci/actions/publish_main
         with:
+          docker_hub_organization: prometheuscommunity
           docker_hub_login: ${{ secrets.docker_hub_login }}
           docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_organization: prometheuscommunity
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
 
@@ -95,8 +98,10 @@ jobs:
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
       - uses: ./.github/promci/actions/publish_release
         with:
+          docker_hub_organization: prometheuscommunity
           docker_hub_login: ${{ secrets.docker_hub_login }}
           docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_organization: prometheuscommunity
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
           github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Actions are currently failing to publish the images because the image names are incorrect. I'm not positive if there are more changes necessary yet, but this should correct the organization name.

See https://github.com/prometheus-community/elasticsearch_exporter/actions/runs/13350556606/job/37286525153