### PR TITLE
Remove circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,52 +1,36 @@
 ---
+# This project has switched to GitHub actions.
+# Circle CI is not disabled repository-wise so that previous pull requests
+# continue working.
+# This file does not generate any CircleCI workflow.
+
 version: 2.1
-orbs:
-  prometheus: prometheus/prometheus@0.17.1
+
 executors:
-  # This must match .promu.yml.
+
   golang:
     docker:
-      - image: cimg/go:1.23
+      - image: busybox
+
 jobs:
-  test:
+  noopjob:
     executor: golang
+
     steps:
-      - prometheus/setup_environment
-      - run: make
-      - prometheus/store_artifact:
-          file: elasticsearch_exporter
+      - run:
+          command: "true"
+
+
 workflows:
   version: 2
   elasticsearch_exporter:
     jobs:
-      - test:
-          filters:
-            tags:
-              only: /.*/
-      - prometheus/build:
-          name: build
-          filters:
-            tags:
-              only: /.*/
-      - prometheus/publish_master:
-          context: org-context
-          docker_hub_organization: prometheuscommunity
-          quay_io_organization: prometheuscommunity
-          requires:
-            - test
-            - build
+      - noopjob
+    triggers:
+      - schedule:
+          cron: "0 0 30 2 *"
           filters:
             branches:
-              only: master
-      - prometheus/publish_release:
-          context: org-context
-          docker_hub_organization: prometheuscommunity
-          quay_io_organization: prometheuscommunity
-          requires:
-            - test
-            - build
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+              only:
+                - main
+                - master

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,6 @@
 go:
-    # This must match .circle/config.yml.
+    # Whenever the Go version is updated here,
+    # .github/workflows should also be updated.
     version: 1.23
 repository:
     path: github.com/prometheus-community/elasticsearch_exporter


### PR DESCRIPTION
We have moved to GitHub Actions, so disable CircleCI jobs. Will revisit removing this file in the future.