### PR TITLE
Remove unused golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,6 @@ issues:
         - errcheck
 
 linters-settings:
-  errcheck:
-    exclude-functions: scripts/errcheck_excludes.txt
   revive:
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter

--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -1,2 +1,0 @@
-// Used in HTTP handlers, any error is handled by the server itself.
-(net/http.ResponseWriter).Write


### PR DESCRIPTION
This config isn't needed because we're the code doesn't fail the linter check. The config is however preventing golangci-lint from being upgraded because this does not pass the schema validation.