### PR TITLE
Add pprof for profiling

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	_ "net/http/pprof" // Enable pprof metrics
 	"net/url"
 	"os"
 	"os/signal"

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	_ "net/http/pprof" // Enable pprof metrics
+	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"os/signal"


### PR DESCRIPTION
We have received reports of excessive memory usage for the exporter. Pprof provides a mechanism for users to dump the heap which should provide useful information about what memory has been allocated.