### PR TITLE
Don't log collector errors

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -185,7 +185,7 @@ func execute(ctx context.Context, name string, c Collector, ch chan<- prometheus
 		if IsNoDataError(err) {
 			logger.Debug("collector returned no data", "name", name, "duration_seconds", duration.Seconds(), "err", err)
 		} else {
-			logger.Error("collector failed", "name", name, "duration_seconds", duration.Seconds(), "err", err)
+			logger.Warn("collector failed", "name", name, "duration_seconds", duration.Seconds(), "err", err)
 		}
 		success = 0
 	} else {


### PR DESCRIPTION
Avoid logging collector failures at Error level to avoid log spam.