### PR TITLE
Do not log input URL string

### DIFF
--- a/collector/util.go
+++ b/collector/util.go
@@ -29,7 +29,7 @@ func getURL(ctx context.Context, hc *http.Client, log *slog.Logger, u string) ([
 
 	resp, err := hc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %s: %v", u, err)
+		return nil, err
 	}
 
 	defer func() {


### PR DESCRIPTION
The error itself already has the sanitized URL so there is no need to log the sensitive input string.