### PR TITLE
feat: add elasticsearch_node_shards_state metric

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -432,11 +432,6 @@ var (
 	)
 )
 
-type labels struct {
-	keys   func(...string) []string
-	values func(*clusterinfo.Response, ...string) []string
-}
-
 // Indices information struct
 type Indices struct {
 	logger          *slog.Logger

--- a/metrics.md
+++ b/metrics.md
@@ -89,6 +89,8 @@
 | elasticsearch_indices_settings_replicas                              | gauge      |             | Index setting value for index.replicas                                                              |
 | elasticsearch_indices_shards_docs                                    | gauge      | 3           | Count of documents on this shard                                                                    |
 | elasticsearch_indices_shards_docs_deleted                            | gauge      | 3           | Count of deleted documents on each shard                                                            |
+| elasticsearch_node_shards_total                                      | gauge      | 2           | Total shards per node                                                                               |
+| elasticsearch_node_shards_state                                      | gauge      | 4           | Shard state allocated per node by index and shard (0=unassigned, 10=primary started, 11=primary initializing, 12=primary relocating, 20=replica started, 21=replica initializing, 22=replica relocating). |
 | elasticsearch_indices_store_size_bytes                               | gauge      | 1           | Current size of stored index data in bytes                                                          |
 | elasticsearch_indices_store_size_bytes_primary                       | gauge      |             | Current size of stored index data in bytes with only primary shards on all nodes                    |
 | elasticsearch_indices_store_size_bytes_total                         | gauge      |             | Current size of stored index data in bytes with all shards on all nodes                             |


### PR DESCRIPTION
Hi there, my first contribution on this project! Let me know your thoughts.

# Context

Inspired by [cerebro](https://github.com/lmenezes/cerebro), I want to create a dashboard in Grafana to visualize shard distribution, state and movements over time. This helps during scale up periods and diagnose imbalances. I tried to use `count(elasticsearch_indices_shards_docs) by (index, node)` metric, but that didn't give me proper node name (e.g. 4n6k9UN4SZG-n3MjOAnszA) and a distinction of primary, replica and shard states.

# Changes

- Fix: add `elasticsearch_node_shards_total` on metrics.md (missing)
- Refactor: simplify shards.go to be more consistent with other files like indices.go
- Feat: add `elasticsearch_node_shards_state` metric with the following encoding (chosen arbitrarily):

```
0=unassigned
10=primary started
11=primary initializing
12=primary relocating
20=replica started
21=replica initializing
22=replica relocating
```

This allows me to create a Matrix with nodes as rows, indices as columns, and color the cells based on the value. The metric is flexible, has more labels but still low in cardinality due to limited possible values.