### PR TITLE
feat: add node label on elasticsearch_nodes_roles metric

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -77,7 +77,7 @@ var nodesRolesMetric = prometheus.NewDesc(
 
 var (
 	defaultNodeLabels               = []string{"cluster", "host", "name", "es_master_node", "es_data_node", "es_ingest_node", "es_client_node"}
-	defaultRoleLabels               = []string{"cluster", "host", "name"}
+	defaultRoleLabels               = []string{"cluster", "host", "name", "node"}
 	defaultThreadPoolLabels         = append(defaultNodeLabels, "type")
 	defaultBreakerLabels            = append(defaultNodeLabels, "breaker")
 	defaultIndexingPressureLabels   = []string{"cluster", "host", "name", "indexing_pressure"}
@@ -1905,7 +1905,7 @@ func (c *Nodes) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	for _, node := range nodeStatsResp.Nodes {
+	for nodeID, node := range nodeStatsResp.Nodes {
 		// Handle the node labels metric
 		roles := getRoles(node)
 
@@ -1919,6 +1919,7 @@ func (c *Nodes) Collect(ch chan<- prometheus.Metric) {
 				nodeStatsResp.ClusterName,
 				node.Host,
 				node.Name,
+				nodeID,
 				role,
 			}
 

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -340,18 +340,18 @@ func TestNodesStats(t *testing.T) {
             elasticsearch_jvm_uptime_seconds{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="bVrN1Hx",type="mapped"} 14.845
             # HELP elasticsearch_nodes_roles Node roles
             # TYPE elasticsearch_nodes_roles gauge
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="client"} 1
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="data"} 1
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="data_cold"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="data_content"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="data_frozen"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="data_hot"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="data_warm"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="ingest"} 1
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="master"} 1
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="ml"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="remote_cluster_client"} 0
-            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",role="transform"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="client"} 1
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="data"} 1
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="data_cold"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="data_content"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="data_frozen"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="data_hot"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="data_warm"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="ingest"} 1
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="master"} 1
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="ml"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="remote_cluster_client"} 0
+            elasticsearch_nodes_roles{cluster="elasticsearch",host="127.0.0.1",name="bVrN1Hx",node="bVrN1HxvQLy795ZLNg2XNw",role="transform"} 0
             # HELP elasticsearch_os_cpu_percent Percent CPU used by OS
             # TYPE elasticsearch_os_cpu_percent gauge
             elasticsearch_os_cpu_percent{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="bVrN1Hx"} 23
@@ -799,18 +799,18 @@ func TestNodesStats(t *testing.T) {
              elasticsearch_jvm_uptime_seconds{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="9_P7yui",type="mapped"} 16.456
              # HELP elasticsearch_nodes_roles Node roles
              # TYPE elasticsearch_nodes_roles gauge
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="client"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="data"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="data_cold"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="data_content"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="data_frozen"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="data_hot"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="data_warm"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="ingest"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="master"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="ml"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="remote_cluster_client"} 0
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",role="transform"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="client"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="data"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="data_cold"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="data_content"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="data_frozen"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="data_hot"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="data_warm"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="ingest"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="master"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="ml"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="remote_cluster_client"} 0
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="9_P7yui",node="9_P7yuiySjG7OAN6NRbBRA",role="transform"} 0
              # HELP elasticsearch_os_cpu_percent Percent CPU used by OS
              # TYPE elasticsearch_os_cpu_percent gauge
              elasticsearch_os_cpu_percent{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="9_P7yui"} 30
@@ -1322,18 +1322,18 @@ func TestNodesStats(t *testing.T) {
              elasticsearch_jvm_uptime_seconds{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="aaf5a8a0bceb",type="mapped"} 21.844
              # HELP elasticsearch_nodes_roles Node roles
              # TYPE elasticsearch_nodes_roles gauge
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="client"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="data"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="data_cold"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="data_content"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="data_frozen"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="data_hot"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="data_warm"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="ingest"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="master"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="ml"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="remote_cluster_client"} 1
-             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",role="transform"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="client"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="data"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="data_cold"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="data_content"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="data_frozen"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="data_hot"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="data_warm"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="ingest"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="master"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="ml"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="remote_cluster_client"} 1
+             elasticsearch_nodes_roles{cluster="elasticsearch",host="172.17.0.2",name="aaf5a8a0bceb",node="byoDEtBRSRGZyMKaIpmhCQ",role="transform"} 1
              # HELP elasticsearch_os_cpu_percent Percent CPU used by OS
              # TYPE elasticsearch_os_cpu_percent gauge
              elasticsearch_os_cpu_percent{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="aaf5a8a0bceb"} 37


### PR DESCRIPTION
This pull request updates the `elasticsearch_nodes_roles` metric to include the node ID as a new label, improving the uniqueness and traceability of reported node roles. The change modifies both the metric collection logic and the related tests to ensure the new label is present and validated.

**Enhancements to Node Role Metrics:**

* Added the `node` (node ID) label to the `elasticsearch_nodes_roles` metric definition, making each metric instance uniquely identifiable by node ID in addition to cluster, host, and name.
* Updated the metric collection loop in `collector/nodes.go` to iterate over node IDs and include the node ID as a label value when emitting node role metrics. [[1]](diffhunk://#diff-52c61a58892060f06016efe9436e79af9f9612990bf51e4916b5c2931625dd28L1908-R1908) [[2]](diffhunk://#diff-52c61a58892060f06016efe9436e79af9f9612990bf51e4916b5c2931625dd28R1922)

**Test Updates:**

* Modified test expectations in `collector/nodes_test.go` to require the new `node` label in all `elasticsearch_nodes_roles` metric assertions, ensuring tests validate the updated metric format. [[1]](diffhunk://#diff-85ccf5a07a803251f1cf9fdc7a735231d2e5bd7709e90b31945f199eba662331L343-R354) [[2]](diffhunk://#diff-85ccf5a07a803251f1cf9fdc7a735231d2e5bd7709e90b31945f199eba662331L802-R813) [[3]](diffhunk://#diff-85ccf5a07a803251f1cf9fdc7a735231d2e5bd7709e90b31945f199eba662331L1325-R1336)