### PR TITLE
Fix: Preserve Elasticsearch URL path in stats requests

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -574,7 +574,7 @@ func (i *Indices) Describe(ch chan<- *prometheus.Desc) {
 func (i *Indices) fetchAndDecodeIndexStats(ctx context.Context) (indexStatsResponse, error) {
 	var isr indexStatsResponse
 
-	u := i.url.ResolveReference(&url.URL{Path: "/_all/_stats"})
+	u := i.url.ResolveReference(&url.URL{Path: "_all/_stats"})
 	q := u.Query()
 	q.Set("ignore_unavailable", "true")
 	if i.shards {


### PR DESCRIPTION
# Description

When the Elasticsearch URL contains a path (e.g., `http://example.com/elasticsearch/`), the path is incorrectly stripped when making `_all/_stats` requests, resulting in requests to `http://example.com/_all/_stats` instead of `http://example.com/elasticsearch/_all/_stats`.

The regression was introduced in v1.10.0 when the URL resolution logic was changed from using [`path.Join`](https://github.com/prometheus-community/elasticsearch_exporter/blob/v1.9.0/collector/indices.go#L1116) to `url.ResolveReference`.

```go
package main

import (
    "fmt"
    "net/url"
)

func main() {
    base, _ := url.Parse("http://example.com/elasticsearch/")
    fmt.Println(base.ResolveReference(&url.URL{Path: "/_all/_stats"}))
    fmt.Println(base.ResolveReference(&url.URL{Path: "_all/_stats"}))
}
```

Output

```
http://example.com/_all/_stats
http://example.com/elasticsearch/_all/_stats
```

This PR fixes the URL path handling to ensure custom paths in the Elasticsearch URL are properly preserved when constructing API endpoint requests.