### PR TITLE
feat: add `number_of_shards` to indices settings metrics

### DIFF
--- a/collector/indices_settings.go
+++ b/collector/indices_settings.go
@@ -95,6 +95,21 @@ func NewIndicesSettings(logger *slog.Logger, client *http.Client, url *url.URL) 
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices_settings", "shards"),
+					"index setting number_of_shards",
+					defaultIndicesTotalFieldsLabels, nil,
+				),
+				Value: func(indexSettings Settings) float64 {
+					val, err := strconv.ParseFloat(indexSettings.IndexInfo.NumberOfShards, 64)
+					if err != nil {
+						return float64(defaultTotalFieldsValue)
+					}
+					return val
+				},
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices_settings", "creation_timestamp_seconds"),
 					"index setting creation_date",
 					defaultIndicesTotalFieldsLabels, nil,

--- a/collector/indices_settings_response.go
+++ b/collector/indices_settings_response.go
@@ -31,6 +31,7 @@ type IndexInfo struct {
 	Blocks           Blocks  `json:"blocks"`
 	Mapping          Mapping `json:"mapping"`
 	NumberOfReplicas string  `json:"number_of_replicas"`
+	NumberOfShards   string  `json:"number_of_shards"`
 	CreationDate     string  `json:"creation_date"`
 }
 

--- a/collector/indices_settings_test.go
+++ b/collector/indices_settings_test.go
@@ -78,6 +78,12 @@ func TestIndicesSettings(t *testing.T) {
              elasticsearch_indices_settings_replicas{index="instagram"} 1
              elasticsearch_indices_settings_replicas{index="twitter"} 1
              elasticsearch_indices_settings_replicas{index="viber"} 1
+             # HELP elasticsearch_indices_settings_shards index setting number_of_shards
+             # TYPE elasticsearch_indices_settings_shards gauge
+             elasticsearch_indices_settings_shards{index="facebook"} 10
+             elasticsearch_indices_settings_shards{index="instagram"} 5
+             elasticsearch_indices_settings_shards{index="twitter"} 5
+             elasticsearch_indices_settings_shards{index="viber"} 5
              # HELP elasticsearch_indices_settings_stats_read_only_indices Current number of read only indices within cluster
              # TYPE elasticsearch_indices_settings_stats_read_only_indices gauge
              elasticsearch_indices_settings_stats_read_only_indices 2

--- a/fixtures/indices_settings/6.5.4.json
+++ b/fixtures/indices_settings/6.5.4.json
@@ -56,7 +56,7 @@
     "settings": {
       "index": {
         "creation_date": "1618593199101",
-        "number_of_shards": "5",
+        "number_of_shards": "10",
         "number_of_replicas": "1",
         "uuid": "trZhb_YOTV-RWKitTYw81A",
         "version": {

--- a/metrics.md
+++ b/metrics.md
@@ -87,6 +87,7 @@
 | elasticsearch_indices_settings_stats_read_only_indices               | gauge      | 1           | Count of indices that have read_only_allow_delete=true                                              |
 | elasticsearch_indices_settings_total_fields                          | gauge      |             | Index setting value for index.mapping.total_fields.limit (total allowable mapped fields in a index) |
 | elasticsearch_indices_settings_replicas                              | gauge      |             | Index setting value for index.replicas                                                              |
+| elasticsearch_indices_settings_shards                                | gauge      |             | Index setting value for index.number_of_shards                                                      |
 | elasticsearch_indices_shards_docs                                    | gauge      | 3           | Count of documents on this shard                                                                    |
 | elasticsearch_indices_shards_docs_deleted                            | gauge      | 3           | Count of deleted documents on each shard                                                            |
 | elasticsearch_indices_store_size_bytes                               | gauge      | 1           | Current size of stored index data in bytes                                                          |


### PR DESCRIPTION
Collect metrics for the `number_of_shards` from each index. These changes are pretty much the same as #815 and (#496 older).

- Updated the collector code.
- Added to the corresponding test case.
- Updated `metrics.md` to include the new metric.