### PR TITLE
fix: Attempt HTTP/2 for HTTP client

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,8 +170,9 @@ func main() {
 		var httpTransport http.RoundTripper
 
 		httpTransport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig:   tlsConfig,
+			Proxy:             http.ProxyFromEnvironment,
+			ForceAttemptHTTP2: true,
 		}
 
 		esAPIKey := os.Getenv("ES_API_KEY")
@@ -336,6 +337,7 @@ func main() {
 		baseTransport := &http.Transport{
 			TLSClientConfig:   tlsCfg,
 			Proxy:             http.ProxyFromEnvironment,
+			ForceAttemptHTTP2: true,
 			DisableKeepAlives: true,
 		}
 		var transport http.RoundTripper = baseTransport


### PR DESCRIPTION
Set ForceAttemptHTTP2 on the HTTP transports used by the main client and the probe client so certificate-authenticated OpenSearch endpoints can negotiate HTTP/2 when it is available.

This keeps HTTP/1.1 fallback while avoiding 401 responses with transport-reactor-netty4, where client certificate authorization can fail over the default HTTP/1.1 path.

Fixes #1167