### PR TITLE
Fix duplicate index throttling metric registration

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -283,7 +283,7 @@ var (
 		indicesLabels, nil,
 	)
 	indicesIndexingIsThrottled = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "indices", "indexing_is_throttled"),
+		prometheus.BuildFQName(namespace, "index_stats", "indexing_is_throttled"),
 		"Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)",
 		indicesLabels, nil,
 	)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -107,10 +107,10 @@ func TestIndices(t *testing.T) {
              # TYPE elasticsearch_index_stats_indexing_delete_current gauge
              elasticsearch_index_stats_indexing_delete_current{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_delete_current{cluster="unknown_cluster",index="foo_2"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index="foo_1"} 0
@@ -425,10 +425,10 @@ func TestIndices(t *testing.T) {
              # TYPE elasticsearch_index_stats_indexing_index_failed_total counter
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index="foo_1"} 1.048576e+08
@@ -789,13 +789,13 @@ func TestIndices(t *testing.T) {
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index=".watches"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-data-2"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-es-2-2017.08.23"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".watches"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-data-2"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-es-2-2017.08.23"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".watches"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index=".monitoring-data-2"} 2.097152e+07
@@ -1324,12 +1324,12 @@ func TestIndices(t *testing.T) {
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_3"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index=".geoip_databases"} 2.097152e+07
@@ -1797,12 +1797,12 @@ func TestIndices(t *testing.T) {
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_3"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index=".geoip_databases"} 2.097152e+07

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/promslog"
 )
@@ -1603,4 +1604,15 @@ func TestNodesStats(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodesAndIndicesRegisterTogether(t *testing.T) {
+	u, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(NewNodes(promslog.NewNopLogger(), http.DefaultClient, u, true, "_local"))
+	reg.MustRegister(NewIndices(promslog.NewNopLogger(), http.DefaultClient, u, false, true))
 }


### PR DESCRIPTION
## Summary
- rename the index-level throttling metric to `elasticsearch_index_stats_indexing_is_throttled`
- avoid the registry collision with the node-level `elasticsearch_indices_indexing_is_throttled` metric
- add a regression test to ensure `NewNodes` and `NewIndices` can be registered together

## Reproduction
The issue was reproduced in multi-target `/probe` mode with these flags:
- `--es.uri=`
- `--config.file=/etc/elasticsearch-exporter/exporter-config.yml`
- `--web.listen-address=:9114`
- `--es.all`
- `--es.shards`
- `--es.ssl-skip-verify`

Representative runtime logs:

```text
time=2026-05-26T12:48:36.027Z level=INFO source=tls_config.go:354 msg="Listening on" address=[::]:9114
time=2026-05-26T12:48:36.027Z level=INFO source=tls_config.go:357 msg="TLS is disabled." http2=false address=[::]:9114
2026/05/26 12:49:02 http: panic serving 10.34.29.6:36890: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "elasticsearch_indices_indexing_is_throttled", help: "Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)", constLabels: {}, variableLabels: {index,cluster}} has different label names or a different help string
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(...)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/registry.go:406
main.main.func3({0xdc6940, 0x298a9f4b0690}, 0x298a9f3fb900)
	/app/main.go:403 +0xe3c
```

The same panic repeats on every scrape while `NewNodes()` and `NewIndices()` are both registered.

## Testing
- `env GOCACHE=/Users/wdte/GolandProjects/elasticsearch_exporter/.gocache go test ./collector -run TestNodesAndIndicesRegisterTogether -count=1`

## Notes
- full `go test ./collector/...` is blocked in the current sandbox because existing tests use `httptest.NewServer` and local port binding is not permitted in this environment
