### PR TITLE
collector/nodes: add elasticsearch_indices_search_scroll_current metric

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -721,6 +721,18 @@ func NewNodes(logger *slog.Logger, client *http.Client, url *url.URL, all bool, 
 			{
 				Type: prometheus.GaugeValue,
 				Desc: prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "indices", "search_scroll_current"),
+					"Number of scroll operations currently running",
+					defaultNodeLabels, nil,
+				),
+				Value: func(node NodeStatsNodeResponse) float64 {
+					return float64(node.Indices.Search.ScrollCurrent)
+				},
+				Labels: defaultNodeLabelValues,
+			},
+			{
+				Type: prometheus.GaugeValue,
+				Desc: prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "indices", "docs"),
 					"Count of documents on this node",
 					defaultNodeLabels, nil,

--- a/collector/nodes_response.go
+++ b/collector/nodes_response.go
@@ -247,17 +247,18 @@ type NodeStatsIndicesGetResponse struct {
 
 // NodeStatsIndicesSearchResponse defines node stats search information structure for indices
 type NodeStatsIndicesSearchResponse struct {
-	OpenContext  int64 `json:"open_contexts"`
-	QueryTotal   int64 `json:"query_total"`
-	QueryTime    int64 `json:"query_time_in_millis"`
-	QueryCurrent int64 `json:"query_current"`
-	FetchTotal   int64 `json:"fetch_total"`
-	FetchTime    int64 `json:"fetch_time_in_millis"`
-	FetchCurrent int64 `json:"fetch_current"`
-	SuggestTotal int64 `json:"suggest_total"`
-	SuggestTime  int64 `json:"suggest_time_in_millis"`
-	ScrollTotal  int64 `json:"scroll_total"`
-	ScrollTime   int64 `json:"scroll_time_in_millis"`
+	OpenContext   int64 `json:"open_contexts"`
+	QueryTotal    int64 `json:"query_total"`
+	QueryTime     int64 `json:"query_time_in_millis"`
+	QueryCurrent  int64 `json:"query_current"`
+	FetchTotal    int64 `json:"fetch_total"`
+	FetchTime     int64 `json:"fetch_time_in_millis"`
+	FetchCurrent  int64 `json:"fetch_current"`
+	SuggestTotal  int64 `json:"suggest_total"`
+	SuggestTime   int64 `json:"suggest_time_in_millis"`
+	ScrollTotal   int64 `json:"scroll_total"`
+	ScrollTime    int64 `json:"scroll_time_in_millis"`
+	ScrollCurrent int64 `json:"scroll_current"`
 }
 
 // NodeStatsIndicesFlushResponse defines node stats flush information structure for indices

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -235,6 +235,9 @@ func TestNodesStats(t *testing.T) {
             # HELP elasticsearch_indices_search_scroll_total Total number of scrolls
             # TYPE elasticsearch_indices_search_scroll_total counter
             elasticsearch_indices_search_scroll_total{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="bVrN1Hx"} 0
+            # HELP elasticsearch_indices_search_scroll_current Number of scroll operations currently running
+            # TYPE elasticsearch_indices_search_scroll_current gauge
+            elasticsearch_indices_search_scroll_current{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="bVrN1Hx"} 0
             # HELP elasticsearch_indices_search_suggest_time_seconds Total suggest time in seconds
             # TYPE elasticsearch_indices_search_suggest_time_seconds counter
             elasticsearch_indices_search_suggest_time_seconds{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="127.0.0.1",name="bVrN1Hx"} 0
@@ -694,6 +697,9 @@ func TestNodesStats(t *testing.T) {
              # HELP elasticsearch_indices_search_scroll_total Total number of scrolls
              # TYPE elasticsearch_indices_search_scroll_total counter
              elasticsearch_indices_search_scroll_total{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="9_P7yui"} 0
+             # HELP elasticsearch_indices_search_scroll_current Number of scroll operations currently running
+             # TYPE elasticsearch_indices_search_scroll_current gauge
+             elasticsearch_indices_search_scroll_current{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="9_P7yui"} 0
              # HELP elasticsearch_indices_search_suggest_time_seconds Total suggest time in seconds
              # TYPE elasticsearch_indices_search_suggest_time_seconds counter
              elasticsearch_indices_search_suggest_time_seconds{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="9_P7yui"} 0
@@ -1217,6 +1223,9 @@ func TestNodesStats(t *testing.T) {
              # HELP elasticsearch_indices_search_scroll_total Total number of scrolls
              # TYPE elasticsearch_indices_search_scroll_total counter
              elasticsearch_indices_search_scroll_total{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="aaf5a8a0bceb"} 0
+             # HELP elasticsearch_indices_search_scroll_current Number of scroll operations currently running
+             # TYPE elasticsearch_indices_search_scroll_current gauge
+             elasticsearch_indices_search_scroll_current{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="aaf5a8a0bceb"} 0
              # HELP elasticsearch_indices_search_suggest_time_seconds Total suggest time in seconds
              # TYPE elasticsearch_indices_search_suggest_time_seconds counter
              elasticsearch_indices_search_suggest_time_seconds{cluster="elasticsearch",es_client_node="true",es_data_node="true",es_ingest_node="true",es_master_node="true",host="172.17.0.2",name="aaf5a8a0bceb"} 0


### PR DESCRIPTION
## Summary

Adds the `elasticsearch_indices_search_scroll_current` gauge metric, which tracks the number of scroll operations currently running on a node.

This field (`scroll_current`) is already present in the Elasticsearch nodes stats API response but was not being exposed.

Changes:
- `collector/nodes_response.go`: add `ScrollCurrent int64` field to `NodeStatsIndicesSearchResponse`
- `collector/nodes.go`: register the new gauge metric
- `collector/nodes_test.go`: add expected metric lines for all three ES version fixtures

Closes #938