### PR TITLE
fix(probe): wire cluster info provider into /probe handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -386,12 +386,18 @@ func main() {
 		// version metric
 		reg.MustRegister(versioncollector.NewCollector(name))
 
+		// Per-probe cluster info provider. NewInfoProvider is lazy (fetches on
+		// first GetInfo, then caches), so constructing one per request starts no
+		// background goroutine and is safe to discard when the handler returns.
+		infoProvider := cluster.NewInfoProvider(logger, probeClient, targetURL, *esClusterInfoInterval)
+
 		// Core exporter collector
 		exp, err := collector.NewElasticsearchCollector(
 			logger,
 			[]string{},
 			collector.WithElasticsearchURL(targetURL),
 			collector.WithHTTPClient(probeClient),
+			collector.WithClusterInfoProvider(infoProvider),
 		)
 		if err != nil {
 			http.Error(w, "failed to create exporter", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Every request to the multi-target `/probe` endpoint currently fails with HTTP 500 and body `failed to create exporter`.

## Root cause

The new cluster info retriever (#1052) made `NewElasticsearchCollector` require a cluster info provider:

```go
if e.cluserInfo == nil {
    return nil, fmt.Errorf("cluster info provider is not set")
}
```

The single-target path was updated to pass `WithClusterInfoProvider(...)`, but the `/probe` handler was not, so it always errors at construction and the handler returns `failed to create exporter`.

## Fix

Build a per-request `cluster.InfoProvider` in the `/probe` handler and pass it via `WithClusterInfoProvider`, mirroring single-target mode. `NewInfoProvider` is lazy (fetches `/` on first `GetInfo`, then caches), so constructing one per request starts no background goroutine and is safe to discard when the handler returns.

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./...` pass.
- Verified end-to-end against a mock target: `/probe?target=...` now returns HTTP 200 with metrics (including `elasticsearch_version` and `elasticsearch_scrape_success{collector="cluster-info"} 1`) instead of HTTP 500.

## Notes

Distinct from #1112 (collector reuse producing an incorrect `elasticsearch_version` on `/probe`); this PR fixes `/probe` never succeeding at all. Affects master since #1052 (not in a tagged release).

Fixes #1185