### PR TITLE
fix(indices): avoid fqName collision on indexing_is_throttled

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -284,7 +284,7 @@ var (
 		indicesLabels, nil,
 	)
 	indicesIndexingIsThrottled = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "indices", "indexing_is_throttled"),
+		prometheus.BuildFQName(namespace, "index_stats", "indexing_is_throttled"),
 		"Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)",
 		indicesLabels, nil,
 	)

--- a/collector/indices_test.go
+++ b/collector/indices_test.go
@@ -107,10 +107,10 @@ func TestIndices(t *testing.T) {
              # TYPE elasticsearch_index_stats_indexing_delete_current gauge
              elasticsearch_index_stats_indexing_delete_current{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_delete_current{cluster="unknown_cluster",index="foo_2"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index="foo_1"} 0
@@ -425,10 +425,10 @@ func TestIndices(t *testing.T) {
              # TYPE elasticsearch_index_stats_indexing_index_failed_total counter
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index="foo_1"} 1.048576e+08
@@ -789,13 +789,13 @@ func TestIndices(t *testing.T) {
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index=".watches"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-data-2"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-es-2-2017.08.23"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".watches"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-data-2"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".monitoring-es-2-2017.08.23"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".watches"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index=".monitoring-data-2"} 2.097152e+07
@@ -1324,12 +1324,12 @@ func TestIndices(t *testing.T) {
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_3"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index=".geoip_databases"} 2.097152e+07
@@ -1797,12 +1797,12 @@ func TestIndices(t *testing.T) {
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_1"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_2"} 0
              elasticsearch_index_stats_indexing_index_failed_total{cluster="unknown_cluster",index="foo_3"} 0
-             # HELP elasticsearch_indices_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
-             # TYPE elasticsearch_indices_indexing_is_throttled gauge
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
-             elasticsearch_indices_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
+             # HELP elasticsearch_index_stats_indexing_is_throttled Whether indexing is currently throttled for an index (1=throttled, 0=not throttled)
+             # TYPE elasticsearch_index_stats_indexing_is_throttled gauge
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index=".geoip_databases"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_1"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_2"} 0
+             elasticsearch_index_stats_indexing_is_throttled{cluster="unknown_cluster",index="foo_3"} 0
              # HELP elasticsearch_index_stats_merge_auto_throttle_bytes_total Total bytes that were auto-throttled during merging
              # TYPE elasticsearch_index_stats_merge_auto_throttle_bytes_total counter
              elasticsearch_index_stats_merge_auto_throttle_bytes_total{cluster="unknown_cluster",index=".geoip_databases"} 2.097152e+07


### PR DESCRIPTION
## Summary

The exporter panics at startup (single-target) or on every scrape (`/probe`) whenever the indices/shards collectors run alongside the always-on nodes collector:

```
panic: a previously registered descriptor with the same fully-qualified name as
Desc{fqName: "elasticsearch_indices_indexing_is_throttled", ...}
has different label names or a different help string
```

Reproduce: `elasticsearch_exporter --es.uri=http://<host>:9200 --es.all --es.indices`.

## Root cause

Two different metrics resolve to the same fully-qualified name `elasticsearch_indices_indexing_is_throttled`:

- nodes collector (since 2019): `BuildFQName(namespace, "indices_indexing", "is_throttled")` — node-level, labels `{cluster,node,...}`
- indices collector (added in #1125): `BuildFQName(namespace, "indices", "indexing_is_throttled")` — index-level, labels `{index,cluster}`

Registering both into one registry is rejected by client_golang. The three sibling index-level indexing metrics added in the same PR (#1125) use the `index_stats` subsystem; only `indexing_is_throttled` used `indices`, which both broke that convention and collided with the node metric.

## Fix

Move the index-level metric to subsystem `index_stats` → `elasticsearch_index_stats_indexing_is_throttled`, matching its three siblings and removing the collision. The metric is unreleased (added after v1.10.0), so no published metric name changes. The node-level metric is unchanged.

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./...` pass (indices test expectations updated; nodes tests unchanged).
- Verified `--es.all --es.indices --es.shards` no longer panics and `/metrics` + `/probe` return HTTP 200.

Fixes #1186