### PR TITLE
perf(shards): stream /_cat/shards decoding to cut peak memory

### DIFF
--- a/collector/shards.go
+++ b/collector/shards.go
@@ -14,8 +14,9 @@
 package collector
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -163,45 +164,46 @@ func (s *Shards) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (s *Shards) getAndParseURL(u *url.URL) ([]ShardResponse, error) {
-	res, err := s.client.Get(u.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get from %s://%s:%s%s: %s",
-			u.Scheme, u.Hostname(), u.Port(), u.Path, err)
-	}
+// streamShards decodes a /_cat/shards JSON array one element at a time,
+// invoking emit for each, so the full shard list is never materialized.
+func streamShards(r io.Reader, emit func(ShardResponse)) error {
+	dec := json.NewDecoder(r)
 
-	defer func() {
-		err = res.Body.Close()
-		if err != nil {
-			s.logger.Warn(
-				"failed to close http.Client",
-				"err", err,
-			)
+	if _, err := dec.Token(); err != nil { // opening '[' of the array
+		return err
+	}
+	for dec.More() {
+		var shard ShardResponse
+		if err := dec.Decode(&shard); err != nil {
+			return err
 		}
-	}()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP Request failed with code %d", res.StatusCode)
+		emit(shard)
 	}
-	var sfr []ShardResponse
-	if err := json.NewDecoder(res.Body).Decode(&sfr); err != nil {
-		s.jsonParseFailures.Inc()
-		return nil, err
-	}
-	return sfr, nil
+	return nil
 }
 
-func (s *Shards) fetchAndDecodeShards() ([]ShardResponse, error) {
+// streamAndAggregateShards GETs /_cat/shards and counts STARTED shards per
+// node while decoding the response one shard at a time. This keeps peak
+// memory proportional to a single shard entry instead of materializing the
+// entire (potentially many-thousand-element) shard list.
+func (s *Shards) streamAndAggregateShards(ctx context.Context, nodeShards map[string]float64) error {
 	u := *s.url
 	u.Path = path.Join(u.Path, "/_cat/shards")
 	q := u.Query()
 	q.Set("format", "json")
 	u.RawQuery = q.Encode()
-	sfr, err := s.getAndParseURL(&u)
-	if err != nil {
-		return sfr, err
-	}
-	return sfr, err
+
+	return fetchURL(ctx, s.client, s.logger, u.String(), func(r io.Reader) error {
+		if err := streamShards(r, func(shard ShardResponse) {
+			if shard.State == "STARTED" {
+				nodeShards[shard.Node]++
+			}
+		}); err != nil {
+			s.jsonParseFailures.Inc()
+			return err
+		}
+		return nil
+	})
 }
 
 // Collect number of shards on each node
@@ -210,21 +212,13 @@ func (s *Shards) Collect(ch chan<- prometheus.Metric) {
 		ch <- s.jsonParseFailures
 	}()
 
-	sr, err := s.fetchAndDecodeShards()
-	if err != nil {
+	nodeShards := make(map[string]float64)
+	if err := s.streamAndAggregateShards(context.TODO(), nodeShards); err != nil {
 		s.logger.Warn(
 			"failed to fetch and decode node shards stats",
 			"err", err,
 		)
 		return
-	}
-
-	nodeShards := make(map[string]float64)
-
-	for _, shard := range sr {
-		if shard.State == "STARTED" {
-			nodeShards[shard.Node]++
-		}
 	}
 
 	for node, shards := range nodeShards {

--- a/collector/shards_stream_test.go
+++ b/collector/shards_stream_test.go
@@ -1,0 +1,311 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// This file is the empirical companion to the streaming change in shards.go,
+// mirroring the approach used for /_all/_stats in PR #1159
+// (collector/indices_stream_test.go and collector/decode_realworld_test.go):
+//
+//   - TestStreamShardsEquivalence : correctness — streaming decode yields the
+//                                   exact same shards (and the exact same
+//                                   per-node aggregation the collector emits)
+//                                   as the previous whole-array json decode.
+//   - BenchmarkShardsDecode        : buffered-vs-streaming on synthetic payloads
+//                                   scaled to real-cluster shard counts, with
+//                                   SetBytes + ReportAllocs (bytes/op is the
+//                                   metric that drives GC pressure).
+//   - BenchmarkShardsDecodeHTTP    : the same contrast over a real
+//                                   *http.Response.Body served by httptest, i.e.
+//                                   the actual production I/O path.
+//   - BenchmarkShardsRetainedHeap  : a direct measurement of live heap retained
+//                                   while the collector works — the buffered
+//                                   path holds the whole []ShardResponse for the
+//                                   duration of the emit loop, the streaming
+//                                   path holds only the small per-node map.
+//
+// The win being demonstrated: streaming keeps peak/retained heap proportional
+// to a single shard entry instead of the full shard list, which on large
+// clusters (and especially under concurrent /probe scrapes) is the difference.
+
+// buildCatShardsPayload synthesizes a /_cat/shards?format=json array with
+// nShards entries, modeled on the real fixture (fixtures/shards/7.15.0.json):
+// every object carries the full eight fields the API returns (index, shard,
+// prirep, state, docs, store, ip, node) even though ShardResponse only decodes
+// four, and roughly one shard in twenty is UNASSIGNED with null docs/store/ip/
+// node — so the buffered baseline pays the realistic parse/allocation cost.
+func buildCatShardsPayload(tb testing.TB, nShards int) []byte {
+	tb.Helper()
+	// nodes scales with shard count so the per-node aggregation map — the only
+	// thing the streaming path retains — reflects a realistic large-cluster node
+	// count instead of a fixed best case.
+	nodes := min(max(nShards/100, 3), 500)
+	var b bytes.Buffer
+	b.Grow(nShards * 160)
+	b.WriteByte('[')
+	for i := 0; i < nShards; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		index := fmt.Sprintf("logs-2026.06.%02d-%06d", i%30, i/8)
+		prirep := "p"
+		if i%3 == 0 {
+			prirep = "r"
+		}
+		if i%20 == 7 { // unassigned replica, null fields like a real response
+			fmt.Fprintf(&b, `{"index":%q,"shard":"%d","prirep":%q,"state":"UNASSIGNED","docs":null,"store":null,"ip":null,"node":null}`,
+				index, i%8, prirep)
+			continue
+		}
+		fmt.Fprintf(&b, `{"index":%q,"shard":"%d","prirep":%q,"state":"STARTED","docs":"%d","store":"%dmb","ip":"10.0.%d.%d","node":"node-%04d"}`,
+			index, i%8, prirep, (i*7)%100000, (i%900)+1, i%256, (i*3)%256, i%nodes)
+	}
+	b.WriteByte(']')
+	data := b.Bytes()
+
+	// Verify the synthetic payload decodes into the production struct.
+	var sink []ShardResponse
+	if err := json.Unmarshal(data, &sink); err != nil {
+		tb.Fatalf("synthetic /_cat/shards payload (n=%d) does not decode: %v", nShards, err)
+	}
+	return data
+}
+
+// startedPerNode is the exact aggregation the Shards collector performs.
+func startedPerNode(shards []ShardResponse) map[string]float64 {
+	agg := make(map[string]float64)
+	for _, s := range shards {
+		if s.State == "STARTED" {
+			agg[s.Node]++
+		}
+	}
+	return agg
+}
+
+func TestStreamShardsEquivalence(t *testing.T) {
+	realFixture, err := os.ReadFile("../fixtures/shards/7.15.0.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := map[string][]byte{
+		"fixture_7.15.0": realFixture,
+		"synthetic_2000": buildCatShardsPayload(t, 2000),
+	}
+
+	for name, data := range inputs {
+		t.Run(name, func(t *testing.T) {
+			var want []ShardResponse
+			if err := json.Unmarshal(data, &want); err != nil {
+				t.Fatal(err)
+			}
+
+			var got []ShardResponse
+			if err := streamShards(bytes.NewReader(data), func(s ShardResponse) {
+				got = append(got, s)
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("streamed shards differ from json.Unmarshal result (got %d entries, want %d)", len(got), len(want))
+			}
+			if !reflect.DeepEqual(startedPerNode(got), startedPerNode(want)) {
+				t.Fatalf("per-node STARTED aggregation differs between streaming and buffered decode")
+			}
+		})
+	}
+}
+
+func BenchmarkShardsDecode(b *testing.B) {
+	for _, n := range []int{1000, 10000, 50000} {
+		data := buildCatShardsPayload(b, n)
+		label := fmt.Sprintf("shards_%d_(%dKB)", n, len(data)/1024)
+
+		// Previous behavior: decode the whole array into []ShardResponse, then aggregate.
+		b.Run(label+"/buffered_decode_slice", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			var sink float64
+			for i := 0; i < b.N; i++ {
+				var sfr []ShardResponse
+				if err := json.NewDecoder(bytes.NewReader(data)).Decode(&sfr); err != nil {
+					b.Fatal(err)
+				}
+				for _, v := range startedPerNode(sfr) {
+					sink += v
+				}
+			}
+			_ = sink
+		})
+
+		// New behavior: decode one shard at a time, aggregating as we go.
+		b.Run(label+"/streaming", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			var sink float64
+			for i := 0; i < b.N; i++ {
+				nodeShards := make(map[string]float64)
+				if err := streamShards(bytes.NewReader(data), func(s ShardResponse) {
+					if s.State == "STARTED" {
+						nodeShards[s.Node]++
+					}
+				}); err != nil {
+					b.Fatal(err)
+				}
+				for _, v := range nodeShards {
+					sink += v
+				}
+			}
+			_ = sink
+		})
+	}
+}
+
+func BenchmarkShardsDecodeHTTP(b *testing.B) {
+	data := buildCatShardsPayload(b, 10000)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	defer ts.Close()
+	client := ts.Client()
+
+	b.Run("buffered_decode_slice", func(b *testing.B) {
+		b.ReportAllocs()
+		var sink float64
+		for i := 0; i < b.N; i++ {
+			resp, err := client.Get(ts.URL)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var sfr []ShardResponse
+			err = json.NewDecoder(resp.Body).Decode(&sfr)
+			resp.Body.Close()
+			if err != nil {
+				b.Fatal(err)
+			}
+			for _, v := range startedPerNode(sfr) {
+				sink += v
+			}
+		}
+		_ = sink
+	})
+
+	b.Run("streaming", func(b *testing.B) {
+		b.ReportAllocs()
+		var sink float64
+		for i := 0; i < b.N; i++ {
+			resp, err := client.Get(ts.URL)
+			if err != nil {
+				b.Fatal(err)
+			}
+			nodeShards := make(map[string]float64)
+			err = streamShards(resp.Body, func(s ShardResponse) {
+				if s.State == "STARTED" {
+					nodeShards[s.Node]++
+				}
+			})
+			resp.Body.Close()
+			if err != nil {
+				b.Fatal(err)
+			}
+			for _, v := range nodeShards {
+				sink += v
+			}
+		}
+		_ = sink
+	})
+}
+
+// retainedHeapBytes returns the increase in live heap attributable to produce()
+// once its result is kept alive across a GC. It approximates the heap the
+// collector holds while it works: the input payload is allocated by the caller
+// (so it is live in both samples and cancels out), and only what produce()
+// returns is still reachable at the second sample. Two GCs settle the baseline,
+// a final GC reclaims the transient garbage, and runtime.KeepAlive prevents the
+// result from being collected before it is measured.
+//
+// This measures post-GC RETAINED heap, not transient peak: it is a conservative
+// lower bound on the buffered path's true peak, which additionally holds the
+// read buffer and decode garbage. The direction is structural (buffered retains
+// the full slice, streaming only the per-node map); the magnitude is reported.
+// Sub-baseline GC jitter can make the delta negative when the retained set is
+// tiny, so it is clamped to zero — the streaming arm is therefore a small
+// near-noise-floor figure, not an exact byte count.
+func retainedHeapBytes(produce func() any) uint64 {
+	runtime.GC()
+	runtime.GC()
+	var m0, m1 runtime.MemStats
+	runtime.ReadMemStats(&m0)
+	result := produce()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+	runtime.KeepAlive(result)
+	if m1.HeapAlloc <= m0.HeapAlloc {
+		return 0
+	}
+	return m1.HeapAlloc - m0.HeapAlloc
+}
+
+func BenchmarkShardsRetainedHeap(b *testing.B) {
+	const n = 50000
+	data := buildCatShardsPayload(b, n)
+
+	// Buffered: the whole []ShardResponse stays live alongside the aggregation
+	// map for the duration of the (real) emit loop.
+	b.Run(fmt.Sprintf("shards_%d/buffered_decode_slice", n), func(b *testing.B) {
+		var sum uint64
+		for i := 0; i < b.N; i++ {
+			sum += retainedHeapBytes(func() any {
+				var sfr []ShardResponse
+				if err := json.NewDecoder(bytes.NewReader(data)).Decode(&sfr); err != nil {
+					b.Fatal(err)
+				}
+				return []any{sfr, startedPerNode(sfr)}
+			})
+		}
+		b.ReportMetric(float64(sum)/float64(b.N)/(1<<20), "retained_MB")
+	})
+
+	// Streaming: only the small per-node map survives; every shard struct is
+	// freed as soon as it is counted.
+	b.Run(fmt.Sprintf("shards_%d/streaming", n), func(b *testing.B) {
+		var sum uint64
+		for i := 0; i < b.N; i++ {
+			sum += retainedHeapBytes(func() any {
+				nodeShards := make(map[string]float64)
+				if err := streamShards(bytes.NewReader(data), func(s ShardResponse) {
+					if s.State == "STARTED" {
+						nodeShards[s.Node]++
+					}
+				}); err != nil {
+					b.Fatal(err)
+				}
+				return nodeShards
+			})
+		}
+		b.ReportMetric(float64(sum)/float64(b.N)/(1<<20), "retained_MB")
+	})
+}


### PR DESCRIPTION
## Summary

Streams `/_cat/shards` decoding one shard at a time so the Shards collector's retained heap is proportional to the cluster's **node count** instead of the **full shard list**. Same approach #1159 applied to `/_all/_stats`.

## Motivation

`Shards.Collect` decoded the entire `/_cat/shards?format=json` response into a `[]ShardResponse` and then aggregated STARTED shards per node. On a cluster with many thousands of shards that slice (a struct with four retained strings per shard) stays live for the whole aggregation, and in multi-target `/probe` mode it is allocated per concurrent request. Only the small per-node count map is actually needed.

## Change

`streamShards` decodes the JSON array element-by-element via `encoding/json`'s token API; `streamAndAggregateShards` feeds each shard straight into the per-node map through the shared `fetchURL` helper. `Collect` never materializes `[]ShardResponse`. Decoded output is unchanged.

## Benchmarks

`darwin/arm64, go1.26`, `go test ./collector/ -bench BenchmarkShards -benchmem`. Synthetic `/_cat/shards` payloads modeled on the real fixture (all 8 API fields per object, ~1/20 UNASSIGNED with nulls, node cardinality scaled with shard count).

**Allocation / throughput** (`BenchmarkShardsDecode`, `BenchmarkShardsDecodeHTTP`):

| payload | bytes/op buffered → streaming | reduction | throughput |
|---|---|---|---|
| 1,000 shards / 141 KB | 709 KB → 107 KB | −84.9% | 160 → 171 MB/s |
| 10,000 shards / 1.4 MB | 7.47 MB → 1.05 MB | −85.9% | 161 → 170 MB/s |
| 50,000 shards / 7.1 MB | 35.9 MB → 5.26 MB | −85.4% | 170 → 167 MB/s |
| 10,000 over a real HTTP body | 7.50 MB → 1.06 MB | −85.9% | — |

Allocation *count* rises ~33% (more, smaller, short-lived per-element decodes); total **bytes** — the driver of GC pressure — drop ~85%. Throughput is unchanged.

**Retained live heap** (`BenchmarkShardsRetainedHeap`, 50,000 shards / 7.1 MB / ~500 nodes) — heap still live after decode+aggregate, i.e. what the collector holds during the emit loop:

| | retained live heap |
|---|---|
| buffered (whole `[]ShardResponse` + map) | ~5.4 MB |
| streaming (per-node map only) | ~34 KB |

The buffered slice is eliminated; only the per-node map (which scales with node count, not shard count) is retained — ~160× lower for this case. This benchmark measures post-GC *retained* heap, a conservative lower bound on the buffered path's transient peak (which also holds the read buffer and decode garbage); sub-baseline GC jitter is clamped to zero, so the streaming figure is a small near-floor number.

<details><summary>raw benchmark output</summary>

```
BenchmarkShardsDecode/shards_1000_(141KB)/buffered_decode_slice-12        899µs   159.75 MB/s    709189 B/op     2982 allocs/op
BenchmarkShardsDecode/shards_1000_(141KB)/streaming-12                    849µs   170.59 MB/s    106968 B/op     3962 allocs/op
BenchmarkShardsDecode/shards_10000_(1424KB)/buffered_decode_slice-12      9.06ms  161.00 MB/s   7465221 B/op    29549 allocs/op
BenchmarkShardsDecode/shards_10000_(1424KB)/streaming-12                  8.58ms  169.98 MB/s   1049218 B/op    39518 allocs/op
BenchmarkShardsDecode/shards_50000_(7126KB)/buffered_decode_slice-12      43.0ms  169.81 MB/s  35900520 B/op   147564 allocs/op
BenchmarkShardsDecode/shards_50000_(7126KB)/streaming-12                  43.6ms  167.33 MB/s   5256671 B/op   197524 allocs/op
BenchmarkShardsDecodeHTTP/buffered_decode_slice-12                        9.41ms                7500154 B/op    29698 allocs/op
BenchmarkShardsDecodeHTTP/streaming-12                                    8.95ms                1060937 B/op    39598 allocs/op
BenchmarkShardsRetainedHeap/shards_50000/buffered_decode_slice-12                       5.402 retained_MB
BenchmarkShardsRetainedHeap/shards_50000/streaming-12                                   0.03334 retained_MB
```
</details>

## Testing

- `TestStreamShardsEquivalence`: streaming decode produces byte-for-byte the same shards and the same per-node STARTED aggregation as the previous whole-array `json.Unmarshal`, over the real fixture (`fixtures/shards/7.15.0.json`) and a synthetic payload.
- Existing `TestShards` unchanged and passing.
- `go test -race ./...`, `go vet ./...`, and `golangci-lint run` are clean.

## Notes

Follows #1159, which streamed `/_all/_stats`. The Shards collector remains a direct-registration `prometheus.Collector`; no metric names or labels change.

Fixes #1188