### PR TITLE
fix: Use logger.Debug instead of Printf for data stream stats

### DIFF
--- a/collector/data_stream.go
+++ b/collector/data_stream.go
@@ -15,7 +15,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -92,7 +91,7 @@ func (ds *DataStream) Update(ctx context.Context, uc UpdateContext, ch chan<- pr
 	}
 
 	for _, dataStream := range dsr.DataStreamStats {
-		fmt.Printf("Metric: %+v", dataStream)
+		ds.logger.Debug("data stream stats", "data_stream", dataStream.DataStream, "backing_indices", dataStream.BackingIndices, "store_size_bytes", dataStream.StoreSizeBytes)
 
 		ch <- prometheus.MustNewConstMetric(
 			dataStreamBackingIndicesTotal,


### PR DESCRIPTION
The log fires once per data stream per scrape. With a 15s scrape interval and 20 data streams that's ~80 lines/min written directly to stdout, bypassing the structured logger entirely.

- collector/data_stream.go contained a leftover `fmt.Printf("Metric: %+v", dataStream)` debug statement that printed to stdout on every scrape for every data stream with no way to suppress it
- Replaced with `ds.logger.Debug()` using structured key/value fields, consistent with the pattern used in indices.go and shards.go
- The output is now silent at default log levels and only appears when running with `--log.level=debug`