### PR TITLE
fix(mixin): correct misspelled relocating shards metric

### DIFF
--- a/elasticsearch-mixin/compiled/dashboards/cluster.json
+++ b/elasticsearch-mixin/compiled/dashboards/cluster.json
@@ -196,7 +196,7 @@
                      "type": "prometheus",
                      "uid": "$datasource"
                   },
-                  "expr": "sum(\n  elasticsearch_cluster_health_reloacting_shards{cluster=~\"$cluster\"}\n)\n"
+                  "expr": "sum(\n  elasticsearch_cluster_health_relocating_shards{cluster=~\"$cluster\"}\n)\n"
                }
             ],
             "title": "Relocating",

--- a/elasticsearch-mixin/dashboards/cluster.libsonnet
+++ b/elasticsearch-mixin/dashboards/cluster.libsonnet
@@ -33,7 +33,7 @@ local util = import './util.libsonnet';
             panels.stat.nodes('Active', queries.activeShards),
             panels.stat.nodes('Active Primary', queries.activePrimaryShards),
             panels.stat.nodes('Initializing', queries.initializingShards),
-            panels.stat.nodes('Relocating', queries.reloactingShards),
+            panels.stat.nodes('Relocating', queries.relocatingShards),
             panels.stat.nodes('Unassigned', queries.unassignedShards),
             panels.stat.nodes('DelayedUnassigned', queries.delayedUnassignedShards),
           ]),

--- a/elasticsearch-mixin/dashboards/queries/shard.libsonnet
+++ b/elasticsearch-mixin/dashboards/queries/shard.libsonnet
@@ -34,12 +34,12 @@ local variables = import '../variables.libsonnet';
       |||
     ),
 
-  reloactingShards:
+  relocatingShards:
     prometheusQuery.new(
       '$' + variables.datasource.name,
       |||
         sum(
-          elasticsearch_cluster_health_reloacting_shards{cluster=~"$cluster"}
+          elasticsearch_cluster_health_relocating_shards{cluster=~"$cluster"}
         )
       |||
     ),


### PR DESCRIPTION
The cluster dashboard's **Relocating** stat panel queries `elasticsearch_cluster_health_reloacting_shards`, but the exporter emits `elasticsearch_cluster_health_relocating_shards` ([collector/cluster_health.go](https://github.com/prometheus-community/elasticsearch_exporter/blob/master/collector/cluster_health.go#L168)).

`reloacting` is a transposition of `relocating`, and no such metric is ever exported, so the panel renders **No data** on every deployment.

Noticed while bringing the mixin dashboard up against a live 3-node cluster on exporter v1.11.0: 20 of the 21 metrics the dashboard references resolved, and this was the only one that did not.

### Changes

* `dashboards/queries/shard.libsonnet`: fix the metric name, and rename the `reloactingShards` field to `relocatingShards` since the identifier carries the same typo
* `dashboards/cluster.libsonnet`: update the reference
* `compiled/dashboards/cluster.json`: regenerated

The panel title was already spelled correctly, so nothing user-visible changes apart from the panel now returning data.

### Verification

Regenerated with `scripts/compile-mixin.sh` rather than editing the compiled JSON by hand, using the toolchain versions pinned in `.github/workflows/mixin.yml`. `scripts/lint-jsonnet.sh` passes, and the only change to the compiled output is the metric name in that one expression, so the `git diff --exit-code` check should be satisfied.

Happy to add a CHANGELOG entry if you would like one. I left it out since those entries reference PR numbers.