### PR TITLE
fix(collector): report es_data_node=true for specialized data-tier roles

### DIFF
--- a/collector/nodes.go
+++ b/collector/nodes.go
@@ -69,6 +69,14 @@ func getRoles(node NodeStatsNodeResponse) map[string]bool {
 	return roles
 }
 
+// isDataNode reports whether a node holds any data role, including the
+// specialized data tiers (data_content, data_hot, data_warm, data_cold,
+// data_frozen) introduced alongside the generic "data" role.
+func isDataNode(roles map[string]bool) bool {
+	return roles["data"] || roles["data_content"] || roles["data_hot"] ||
+		roles["data_warm"] || roles["data_cold"] || roles["data_frozen"]
+}
+
 var nodesRolesMetric = prometheus.NewDesc(
 	prometheus.BuildFQName(namespace, "nodes", "roles"),
 	"Node roles",
@@ -92,7 +100,7 @@ var (
 			node.Host,
 			node.Name,
 			fmt.Sprintf("%t", roles["master"]),
-			fmt.Sprintf("%t", roles["data"]),
+			fmt.Sprintf("%t", isDataNode(roles)),
 			fmt.Sprintf("%t", roles["ingest"]),
 			fmt.Sprintf("%t", roles["client"]),
 		}

--- a/collector/nodes_test.go
+++ b/collector/nodes_test.go
@@ -26,6 +26,31 @@ import (
 	"github.com/prometheus/common/promslog"
 )
 
+func TestIsDataNode(t *testing.T) {
+	tests := []struct {
+		name  string
+		roles []string
+		want  bool
+	}{
+		{"generic data role", []string{"data"}, true},
+		{"data_content tier", []string{"data_content"}, true},
+		{"data_hot tier", []string{"data_hot"}, true},
+		{"data_warm tier", []string{"data_warm"}, true},
+		{"data_cold tier", []string{"data_cold"}, true},
+		{"data_frozen tier", []string{"data_frozen"}, true},
+		{"master only", []string{"master"}, false},
+		{"ingest only", []string{"ingest"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := NodeStatsNodeResponse{Roles: tt.roles}
+			if got := isDataNode(getRoles(node)); got != tt.want {
+				t.Errorf("isDataNode(getRoles(%v)) = %v, want %v", tt.roles, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNodesStats(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Motivation:
Nodes running only a specialized data-tier role (data_content, data_hot,
data_warm, data_cold, data_frozen) were reported with the label
es_data_node="false" on all node-scoped metrics (e.g.
elasticsearch_filesystem_data_available_bytes), even though they are
genuine data nodes. getRoles() already tracks these roles correctly,
but defaultNodeLabelValues only checked roles["data"], the generic
role name used before Elasticsearch introduced data tiers. This made
it impossible to select data-node metrics by es_data_node="true" on
any cluster using tiered data nodes.

This is a metric-labeling bug only: the per-role
elasticsearch_nodes_roles metric (which already reports each role,
including the data tiers, individually) is unaffected, and no other
user-visible behavior changes.

Approach:
Add an isDataNode() helper that treats a node as a data node if any of
roles["data"], roles["data_content"], roles["data_hot"],
roles["data_warm"], roles["data_cold"], or roles["data_frozen"] is
true, and use it in defaultNodeLabelValues instead of the bare
roles["data"] lookup.

Validation:
  go build ./...
  go test ./collector/... -run 'TestIsDataNode|TestNodesStats' -v
  go test ./...
All passed, including a new TestIsDataNode covering each data-tier
role individually plus master-only/ingest-only negative cases.

Fixes #779

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>