### PR TITLE
Fix goroutine leak in /probe multi-target endpoint

### DIFF
--- a/collector/indices.go
+++ b/collector/indices.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"sort"
 	"strconv"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -467,6 +468,20 @@ type Indices struct {
 	aliases         bool
 	clusterInfoCh   chan *clusterinfo.Response
 	lastClusterInfo *clusterinfo.Response
+	closeOnce       sync.Once
+}
+
+// Close stops the background cluster info receive loop started in NewIndices by
+// closing its update channel. It is safe to call multiple times. Short-lived
+// instances (e.g. one created per /probe request) MUST call Close to avoid
+// leaking the receive-loop goroutine. Do not call Close on an instance
+// registered with a clusterinfo.Retriever (single-target mode), where the
+// retriever owns the channel and continues to send updates for the process
+// lifetime.
+func (i *Indices) Close() {
+	i.closeOnce.Do(func() {
+		close(i.clusterInfoCh)
+	})
 }
 
 // NewIndices defines Indices Prometheus metrics

--- a/collector/probe_leak_test.go
+++ b/collector/probe_leak_test.go
@@ -1,0 +1,71 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"net/http"
+	"net/url"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/promslog"
+)
+
+// settleGoroutines polls the goroutine count a few times so background
+// receive-loop goroutines that are exiting have a chance to unwind before we
+// take a measurement.
+func settleGoroutines() int {
+	var n int
+	for i := 0; i < 50; i++ {
+		runtime.Gosched()
+		time.Sleep(2 * time.Millisecond)
+		n = runtime.NumGoroutine()
+	}
+	return n
+}
+
+// TestProbeCollectorsCloseNoGoroutineLeak guards against the /probe goroutine
+// leak: NewShards and NewIndices each start a cluster info receive loop that
+// only exits when their channel is closed. In /probe mode a fresh collector is
+// built per scrape and nothing feeds or closes that channel, so without Close()
+// every scrape would leak two goroutines. Creating and closing many collectors
+// must return the goroutine count to its baseline.
+func TestProbeCollectorsCloseNoGoroutineLeak(t *testing.T) {
+	u, err := url.Parse("http://localhost:9200")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := settleGoroutines()
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		s := NewShards(promslog.NewNopLogger(), http.DefaultClient, u)
+		idx := NewIndices(promslog.NewNopLogger(), http.DefaultClient, u, false, false)
+		s.Close()
+		idx.Close()
+		// Close must be idempotent and safe to call more than once.
+		s.Close()
+		idx.Close()
+	}
+
+	after := settleGoroutines()
+
+	// Each iteration leaks 2 goroutines without the fix (2*n == 100 here), so a
+	// small tolerance distinguishes cleanly from the leaking behaviour.
+	if after > before+10 {
+		t.Fatalf("goroutine leak: created and closed %d Shards+Indices collectors, goroutines before=%d after=%d", n, before, after)
+	}
+}

--- a/collector/shards.go
+++ b/collector/shards.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -41,9 +42,23 @@ type Shards struct {
 	url             *url.URL
 	clusterInfoCh   chan *clusterinfo.Response
 	lastClusterInfo *clusterinfo.Response
+	closeOnce       sync.Once
 
 	nodeShardMetrics  []*nodeShardMetric
 	jsonParseFailures prometheus.Counter
+}
+
+// Close stops the background cluster info receive loop started in NewShards by
+// closing its update channel. It is safe to call multiple times. Short-lived
+// instances (e.g. one created per /probe request) MUST call Close to avoid
+// leaking the receive-loop goroutine. Do not call Close on an instance
+// registered with a clusterinfo.Retriever (single-target mode), where the
+// retriever owns the channel and continues to send updates for the process
+// lifetime.
+func (s *Shards) Close() {
+	s.closeOnce.Do(func() {
+		close(s.clusterInfoCh)
+	})
 }
 
 // ClusterLabelUpdates returns a pointer to a channel to receive cluster info updates. It implements the

--- a/main.go
+++ b/main.go
@@ -410,6 +410,12 @@ func main() {
 		if *esExportIndices || *esExportShards {
 			shardsC := collector.NewShards(logger, probeClient, targetURL)
 			indicesC := collector.NewIndices(logger, probeClient, targetURL, *esExportShards, *esExportIndexAliases)
+			// These collectors start a background cluster info receive loop that
+			// only exits when their channel is closed. In /probe mode nothing feeds
+			// or closes that channel, so close them when the handler returns to
+			// avoid leaking two goroutines per scrape.
+			defer shardsC.Close()
+			defer indicesC.Close()
 			reg.MustRegister(shardsC)
 			reg.MustRegister(indicesC)
 		}


### PR DESCRIPTION
Fixes #1225

## Problem

The `Shards` and `Indices` collectors start a background cluster-info receive loop in their constructor that only exits when their update channel is closed:

```go
go func() {
    for ci := range shards.clusterInfoCh { ... } // blocks until channel closed
}()
```

In single-target mode a long-lived `clusterinfo.Retriever` owns that channel for the process lifetime, so this is fine. But the `/probe` handler builds a fresh `Shards` and `Indices` **per scrape** and never registers them with a retriever, so nothing ever closes the channel. Each `/probe` scrape leaks two goroutines, and each leaked goroutine retains the collector, its per-probe HTTP client and registry, so resident memory grows unbounded until the process is OOMKilled.

Reproduced on v1.11.0: `go_goroutines` grows by exactly 2 per `/probe` request and never drops (full analysis and pprof dump in #1225).

## Fix

- Add an idempotent `Close()` method (guarded by `sync.Once`) to `Shards` and `Indices` that closes `clusterInfoCh`, letting the receive-loop goroutine return.
- Call `Close()` via `defer` in the `/probe` handler so both goroutines exit when the handler returns.

Single-target mode is unchanged, it never calls `Close()`, so the retriever keeps owning the channel.

## Verification

Before/after, hammering `/probe` against a dead target (the goroutines are started at construction, so a live ES is not needed):

| | after 60 probes | after 120 probes |
|---|---|---|
| before | 23 | **143** (~ +2 / probe) |
| after | 16 | **14** (flat) |

Added a regression test (`collector/probe_leak_test.go`) that creates and closes 50 of each collector and asserts the goroutine count returns to baseline. `go test ./...` passes; `gofmt`/`go vet` clean.

## Note

I went with the minimal, lifecycle-based fix that mirrors the existing consumer model. An alternative would be to skip starting the receive-loop goroutine entirely when no retriever is attached (i.e. in `/probe` mode).
