### PR TITLE
fix(collector): use gauge type for data stream metrics

### DIFF
--- a/collector/data_stream.go
+++ b/collector/data_stream.go
@@ -95,14 +95,14 @@ func (ds *DataStream) Update(ctx context.Context, uc UpdateContext, ch chan<- pr
 
 		ch <- prometheus.MustNewConstMetric(
 			dataStreamBackingIndicesTotal,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			float64(dataStream.BackingIndices),
 			dataStream.DataStream,
 		)
 
 		ch <- prometheus.MustNewConstMetric(
 			dataStreamStoreSizeBytes,
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			float64(dataStream.StoreSizeBytes),
 			dataStream.DataStream,
 		)

--- a/collector/data_stream_test.go
+++ b/collector/data_stream_test.go
@@ -36,11 +36,11 @@ func TestDataStream(t *testing.T) {
 			name: "7.15.0",
 			file: "../fixtures/datastream/7.15.0.json",
 			want: `# HELP elasticsearch_data_stream_backing_indices_total Number of backing indices
-            # TYPE elasticsearch_data_stream_backing_indices_total counter
+            # TYPE elasticsearch_data_stream_backing_indices_total gauge
             elasticsearch_data_stream_backing_indices_total{data_stream="bar"} 2
             elasticsearch_data_stream_backing_indices_total{data_stream="foo"} 5
             # HELP elasticsearch_data_stream_store_size_bytes Store size of data stream
-            # TYPE elasticsearch_data_stream_store_size_bytes counter
+            # TYPE elasticsearch_data_stream_store_size_bytes gauge
             elasticsearch_data_stream_store_size_bytes{data_stream="bar"} 6.7382272e+08
             elasticsearch_data_stream_store_size_bytes{data_stream="foo"} 4.29205396e+08
 			`,


### PR DESCRIPTION
The data stream collector emits `elasticsearch_data_stream_store_size_bytes` and `elasticsearch_data_stream_backing_indices_total` as counters, but neither value is monotonic: store size shrinks when segments merge or documents are deleted, and the backing index count drops when ILM deletes or shrinks rolled-over indices. This was reported in #797.

This changes both to gauges. Metric names are unchanged, and metrics.md already documents both as gauge, so this also brings the code in line with the docs.

Probably worth a line in the changelog: dashboards applying `rate()`/`increase()` to these series were getting misleading results already, but tooling that keys off the exposed TYPE will see it change from counter to gauge.

Fixes #797
