### PR TITLE
Add cluster label to snapshot metrics

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -40,5 +40,5 @@ func (w wrapCollector) Collect(ch chan<- prometheus.Metric) {
 type mockUpdateContext struct{}
 
 func (m *mockUpdateContext) GetClusterInfo(_ context.Context) (cluster.Info, error) {
-	return cluster.Info{}, nil
+	return cluster.Info{ClusterName: "test-cluster"}, nil
 }

--- a/collector/snapshots.go
+++ b/collector/snapshots.go
@@ -25,13 +25,13 @@ import (
 )
 
 var (
-	defaultSnapshotLabels      = []string{"repository", "state", "version"}
-	defaultSnapshotLabelValues = func(repositoryName string, snapshotStats SnapshotStatDataResponse) []string {
-		return []string{repositoryName, snapshotStats.State, snapshotStats.Version}
+	defaultSnapshotLabels      = []string{"repository", "state", "version", "cluster"}
+	defaultSnapshotLabelValues = func(repositoryName string, snapshotStats SnapshotStatDataResponse, clusterName string) []string {
+		return []string{repositoryName, snapshotStats.State, snapshotStats.Version, clusterName}
 	}
-	defaultSnapshotRepositoryLabels      = []string{"repository"}
-	defaultSnapshotRepositoryLabelValues = func(repositoryName string) []string {
-		return []string{repositoryName}
+	defaultSnapshotRepositoryLabels      = []string{"repository", "cluster"}
+	defaultSnapshotRepositoryLabelValues = func(repositoryName string, clusterName string) []string {
+		return []string{repositoryName, clusterName}
 	}
 )
 
@@ -110,6 +110,11 @@ func NewSnapshots(logger *slog.Logger, u *url.URL, hc *http.Client) (Collector, 
 }
 
 func (c *Snapshots) Update(ctx context.Context, uc UpdateContext, ch chan<- prometheus.Metric) error {
+	clusterInfo, err := uc.GetClusterInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster info: %v", err)
+	}
+
 	// indices
 	snapshotsStatsResp := make(map[string]SnapshotStatsResponse)
 	u := c.u.ResolveReference(&url.URL{Path: "/_snapshot"})
@@ -136,7 +141,7 @@ func (c *Snapshots) Update(ctx context.Context, uc UpdateContext, ch chan<- prom
 			numSnapshots,
 			prometheus.GaugeValue,
 			float64(len(snapshotStats.Snapshots)),
-			defaultSnapshotRepositoryLabelValues(repositoryName)...,
+			defaultSnapshotRepositoryLabelValues(repositoryName, clusterInfo.ClusterName)...,
 		)
 
 		oldest := float64(0)
@@ -147,7 +152,7 @@ func (c *Snapshots) Update(ctx context.Context, uc UpdateContext, ch chan<- prom
 			oldestSnapshotTimestamp,
 			prometheus.GaugeValue,
 			oldest,
-			defaultSnapshotRepositoryLabelValues(repositoryName)...,
+			defaultSnapshotRepositoryLabelValues(repositoryName, clusterInfo.ClusterName)...,
 		)
 
 		latest := float64(0)
@@ -162,7 +167,7 @@ func (c *Snapshots) Update(ctx context.Context, uc UpdateContext, ch chan<- prom
 			latestSnapshotTimestamp,
 			prometheus.GaugeValue,
 			latest,
-			defaultSnapshotRepositoryLabelValues(repositoryName)...,
+			defaultSnapshotRepositoryLabelValues(repositoryName, clusterInfo.ClusterName)...,
 		)
 
 		if len(snapshotStats.Snapshots) == 0 {
@@ -174,43 +179,43 @@ func (c *Snapshots) Update(ctx context.Context, uc UpdateContext, ch chan<- prom
 			numIndices,
 			prometheus.GaugeValue,
 			float64(len(lastSnapshot.Indices)),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			snapshotStartTimestamp,
 			prometheus.GaugeValue,
 			float64(lastSnapshot.StartTimeInMillis/1000),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			snapshotEndTimestamp,
 			prometheus.GaugeValue,
 			float64(lastSnapshot.EndTimeInMillis/1000),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			snapshotNumFailures,
 			prometheus.GaugeValue,
 			float64(len(lastSnapshot.Failures)),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			snapshotNumShards,
 			prometheus.GaugeValue,
 			float64(lastSnapshot.Shards.Total),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			snapshotFailedShards,
 			prometheus.GaugeValue,
 			float64(lastSnapshot.Shards.Failed),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			snapshotSuccessfulShards,
 			prometheus.GaugeValue,
 			float64(lastSnapshot.Shards.Successful),
-			defaultSnapshotLabelValues(repositoryName, lastSnapshot)...,
+			defaultSnapshotLabelValues(repositoryName, lastSnapshot, clusterInfo.ClusterName)...,
 		)
 	}
 

--- a/collector/snapshots_test.go
+++ b/collector/snapshots_test.go
@@ -51,34 +51,34 @@ func TestSnapshots(t *testing.T) {
 			file: "../fixtures/snapshots/1.7.6.json",
 			want: `# HELP elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds Timestamp of the latest SUCCESS or PARTIAL snapshot
 						# TYPE elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds gauge
-						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{repository="test1"} 1.536052142e+09
+						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{cluster="test-cluster",repository="test1"} 1.536052142e+09
 						# HELP elasticsearch_snapshot_stats_number_of_snapshots Number of snapshots in a repository
 						# TYPE elasticsearch_snapshot_stats_number_of_snapshots gauge
-						elasticsearch_snapshot_stats_number_of_snapshots{repository="test1"} 1
+						elasticsearch_snapshot_stats_number_of_snapshots{cluster="test-cluster",repository="test1"} 1
 						# HELP elasticsearch_snapshot_stats_oldest_snapshot_timestamp Timestamp of the oldest snapshot
 						# TYPE elasticsearch_snapshot_stats_oldest_snapshot_timestamp gauge
-						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{repository="test1"} 1.536052142e+09
+						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{cluster="test-cluster",repository="test1"} 1.536052142e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_end_time_timestamp Last snapshot end timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_end_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{repository="test1",state="SUCCESS",version="1.7.6"} 1.536052142e+09
+						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 1.536052142e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_failed_shards Last snapshot failed shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_failed_shards gauge
-						elasticsearch_snapshot_stats_snapshot_failed_shards{repository="test1",state="SUCCESS",version="1.7.6"} 0
+						elasticsearch_snapshot_stats_snapshot_failed_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 0
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_failures Last snapshot number of failures
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_failures gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_failures{repository="test1",state="SUCCESS",version="1.7.6"} 0
+						elasticsearch_snapshot_stats_snapshot_number_of_failures{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 0
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_indices Number of indices in the last snapshot
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_indices gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_indices{repository="test1",state="SUCCESS",version="1.7.6"} 2
+						elasticsearch_snapshot_stats_snapshot_number_of_indices{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 2
 						# HELP elasticsearch_snapshot_stats_snapshot_start_time_timestamp Last snapshot start timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_start_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{repository="test1",state="SUCCESS",version="1.7.6"} 1.536052142e+09
+						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 1.536052142e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_successful_shards Last snapshot successful shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_successful_shards gauge
-						elasticsearch_snapshot_stats_snapshot_successful_shards{repository="test1",state="SUCCESS",version="1.7.6"} 10
+						elasticsearch_snapshot_stats_snapshot_successful_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 10
 						# HELP elasticsearch_snapshot_stats_snapshot_total_shards Last snapshot total shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_total_shards gauge
-						elasticsearch_snapshot_stats_snapshot_total_shards{repository="test1",state="SUCCESS",version="1.7.6"} 10
+						elasticsearch_snapshot_stats_snapshot_total_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="1.7.6"} 10
 `,
 		},
 		{
@@ -86,34 +86,34 @@ func TestSnapshots(t *testing.T) {
 			file: "../fixtures/snapshots/2.4.5.json",
 			want: `# HELP elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds Timestamp of the latest SUCCESS or PARTIAL snapshot
 						# TYPE elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds gauge
-						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{repository="test1"} 1.536053125e+09
+						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{cluster="test-cluster",repository="test1"} 1.536053125e+09
 						# HELP elasticsearch_snapshot_stats_number_of_snapshots Number of snapshots in a repository
 						# TYPE elasticsearch_snapshot_stats_number_of_snapshots gauge
-						elasticsearch_snapshot_stats_number_of_snapshots{repository="test1"} 1
+						elasticsearch_snapshot_stats_number_of_snapshots{cluster="test-cluster",repository="test1"} 1
 						# HELP elasticsearch_snapshot_stats_oldest_snapshot_timestamp Timestamp of the oldest snapshot
 						# TYPE elasticsearch_snapshot_stats_oldest_snapshot_timestamp gauge
-						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{repository="test1"} 1.536053125e+09
+						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{cluster="test-cluster",repository="test1"} 1.536053125e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_end_time_timestamp Last snapshot end timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_end_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{repository="test1",state="SUCCESS",version="2.4.5"} 1.536053126e+09
+						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 1.536053126e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_failed_shards Last snapshot failed shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_failed_shards gauge
-						elasticsearch_snapshot_stats_snapshot_failed_shards{repository="test1",state="SUCCESS",version="2.4.5"} 0
+						elasticsearch_snapshot_stats_snapshot_failed_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 0
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_failures Last snapshot number of failures
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_failures gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_failures{repository="test1",state="SUCCESS",version="2.4.5"} 0
+						elasticsearch_snapshot_stats_snapshot_number_of_failures{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 0
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_indices Number of indices in the last snapshot
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_indices gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_indices{repository="test1",state="SUCCESS",version="2.4.5"} 2
+						elasticsearch_snapshot_stats_snapshot_number_of_indices{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 2
 						# HELP elasticsearch_snapshot_stats_snapshot_start_time_timestamp Last snapshot start timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_start_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{repository="test1",state="SUCCESS",version="2.4.5"} 1.536053125e+09
+						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 1.536053125e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_successful_shards Last snapshot successful shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_successful_shards gauge
-						elasticsearch_snapshot_stats_snapshot_successful_shards{repository="test1",state="SUCCESS",version="2.4.5"} 10
+						elasticsearch_snapshot_stats_snapshot_successful_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 10
 						# HELP elasticsearch_snapshot_stats_snapshot_total_shards Last snapshot total shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_total_shards gauge
-						elasticsearch_snapshot_stats_snapshot_total_shards{repository="test1",state="SUCCESS",version="2.4.5"} 10
+						elasticsearch_snapshot_stats_snapshot_total_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="2.4.5"} 10
 						`,
 		},
 		{
@@ -121,34 +121,34 @@ func TestSnapshots(t *testing.T) {
 			file: "../fixtures/snapshots/5.4.2.json",
 			want: `# HELP elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds Timestamp of the latest SUCCESS or PARTIAL snapshot
 						# TYPE elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds gauge
-						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{repository="test1"} 1.536053353e+09
+						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{cluster="test-cluster",repository="test1"} 1.536053353e+09
 						# HELP elasticsearch_snapshot_stats_number_of_snapshots Number of snapshots in a repository
 						# TYPE elasticsearch_snapshot_stats_number_of_snapshots gauge
-						elasticsearch_snapshot_stats_number_of_snapshots{repository="test1"} 1
+						elasticsearch_snapshot_stats_number_of_snapshots{cluster="test-cluster",repository="test1"} 1
 						# HELP elasticsearch_snapshot_stats_oldest_snapshot_timestamp Timestamp of the oldest snapshot
 						# TYPE elasticsearch_snapshot_stats_oldest_snapshot_timestamp gauge
-						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{repository="test1"} 1.536053353e+09
+						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{cluster="test-cluster",repository="test1"} 1.536053353e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_end_time_timestamp Last snapshot end timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_end_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{repository="test1",state="SUCCESS",version="5.4.2"} 1.536053354e+09
+						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 1.536053354e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_failed_shards Last snapshot failed shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_failed_shards gauge
-						elasticsearch_snapshot_stats_snapshot_failed_shards{repository="test1",state="SUCCESS",version="5.4.2"} 0
+						elasticsearch_snapshot_stats_snapshot_failed_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 0
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_failures Last snapshot number of failures
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_failures gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_failures{repository="test1",state="SUCCESS",version="5.4.2"} 0
+						elasticsearch_snapshot_stats_snapshot_number_of_failures{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 0
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_indices Number of indices in the last snapshot
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_indices gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_indices{repository="test1",state="SUCCESS",version="5.4.2"} 2
+						elasticsearch_snapshot_stats_snapshot_number_of_indices{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 2
 						# HELP elasticsearch_snapshot_stats_snapshot_start_time_timestamp Last snapshot start timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_start_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{repository="test1",state="SUCCESS",version="5.4.2"} 1.536053353e+09
+						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 1.536053353e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_successful_shards Last snapshot successful shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_successful_shards gauge
-						elasticsearch_snapshot_stats_snapshot_successful_shards{repository="test1",state="SUCCESS",version="5.4.2"} 10
+						elasticsearch_snapshot_stats_snapshot_successful_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 10
 						# HELP elasticsearch_snapshot_stats_snapshot_total_shards Last snapshot total shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_total_shards gauge
-						elasticsearch_snapshot_stats_snapshot_total_shards{repository="test1",state="SUCCESS",version="5.4.2"} 10
+						elasticsearch_snapshot_stats_snapshot_total_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 10
 						`,
 		},
 		{
@@ -156,34 +156,34 @@ func TestSnapshots(t *testing.T) {
 			file: "../fixtures/snapshots/5.4.2-failed.json",
 			want: `# HELP elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds Timestamp of the latest SUCCESS or PARTIAL snapshot
 						# TYPE elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds gauge
-						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{repository="test1"} 1.536053353e+09
+						elasticsearch_snapshot_stats_latest_snapshot_timestamp_seconds{cluster="test-cluster",repository="test1"} 1.536053353e+09
 						# HELP elasticsearch_snapshot_stats_number_of_snapshots Number of snapshots in a repository
 						# TYPE elasticsearch_snapshot_stats_number_of_snapshots gauge
-						elasticsearch_snapshot_stats_number_of_snapshots{repository="test1"} 1
+						elasticsearch_snapshot_stats_number_of_snapshots{cluster="test-cluster",repository="test1"} 1
 						# HELP elasticsearch_snapshot_stats_oldest_snapshot_timestamp Timestamp of the oldest snapshot
 						# TYPE elasticsearch_snapshot_stats_oldest_snapshot_timestamp gauge
-						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{repository="test1"} 1.536053353e+09
+						elasticsearch_snapshot_stats_oldest_snapshot_timestamp{cluster="test-cluster",repository="test1"} 1.536053353e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_end_time_timestamp Last snapshot end timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_end_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{repository="test1",state="SUCCESS",version="5.4.2"} 1.536053354e+09
+						elasticsearch_snapshot_stats_snapshot_end_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 1.536053354e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_failed_shards Last snapshot failed shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_failed_shards gauge
-						elasticsearch_snapshot_stats_snapshot_failed_shards{repository="test1",state="SUCCESS",version="5.4.2"} 1
+						elasticsearch_snapshot_stats_snapshot_failed_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 1
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_failures Last snapshot number of failures
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_failures gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_failures{repository="test1",state="SUCCESS",version="5.4.2"} 1
+						elasticsearch_snapshot_stats_snapshot_number_of_failures{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 1
 						# HELP elasticsearch_snapshot_stats_snapshot_number_of_indices Number of indices in the last snapshot
 						# TYPE elasticsearch_snapshot_stats_snapshot_number_of_indices gauge
-						elasticsearch_snapshot_stats_snapshot_number_of_indices{repository="test1",state="SUCCESS",version="5.4.2"} 2
+						elasticsearch_snapshot_stats_snapshot_number_of_indices{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 2
 						# HELP elasticsearch_snapshot_stats_snapshot_start_time_timestamp Last snapshot start timestamp
 						# TYPE elasticsearch_snapshot_stats_snapshot_start_time_timestamp gauge
-						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{repository="test1",state="SUCCESS",version="5.4.2"} 1.536053353e+09
+						elasticsearch_snapshot_stats_snapshot_start_time_timestamp{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 1.536053353e+09
 						# HELP elasticsearch_snapshot_stats_snapshot_successful_shards Last snapshot successful shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_successful_shards gauge
-						elasticsearch_snapshot_stats_snapshot_successful_shards{repository="test1",state="SUCCESS",version="5.4.2"} 10
+						elasticsearch_snapshot_stats_snapshot_successful_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 10
 						# HELP elasticsearch_snapshot_stats_snapshot_total_shards Last snapshot total shards
 						# TYPE elasticsearch_snapshot_stats_snapshot_total_shards gauge
-						elasticsearch_snapshot_stats_snapshot_total_shards{repository="test1",state="SUCCESS",version="5.4.2"} 10
+						elasticsearch_snapshot_stats_snapshot_total_shards{cluster="test-cluster",repository="test1",state="SUCCESS",version="5.4.2"} 10
 						`,
 		},
 	}


### PR DESCRIPTION
This adds a `cluster` label (the cluster name) to all `elasticsearch_snapshot_stats_*` metrics, so snapshot metrics from multiple clusters no longer collide.

As sysadmind noted in #629, "#1052 should unblock this support." This PR is a first consumer of that new API: the collector resolves the cluster name via `UpdateContext.GetClusterInfo` at the start of `Update` and appends `cluster` to the existing metric labels, intended as a pattern other collectors can follow. If `GetClusterInfo` fails the collector returns an error, which goes through the same warn-and-mark-unsuccessful path as any other fetch failure.

The shared test mock now returns a fixed cluster name (`test-cluster`), and the snapshots test asserts the label on every metric.

Fixes #629
